### PR TITLE
Add Cartesian control in Reacher environment

### DIFF
--- a/aegis_gym/envs/aegis_reacher.py
+++ b/aegis_gym/envs/aegis_reacher.py
@@ -21,6 +21,10 @@ class AegisReacherEnv(gym.Env):
         super().__init__()
 
         self.episode_length = 30
+        if control_type == "joints":
+            self.num_actions = 6
+        if control_type == "cartesian":
+            self.num_actions = 3
         self.num_obs = 18
         self.num_actions = 6
         self.target_threshold = 0.02
@@ -72,11 +76,19 @@ class AegisReacherEnv(gym.Env):
         action = np.clip(action, -self.clip_action, self.clip_action)
         self.actions = np.array(action, dtype=np.float32)
 
-        self.dof_pos = self.robot.get_joint_positions()
-        delta = self.actions * self.action_scale
-        dof_pos_target = self.dof_pos + delta
-        self.robot.control_dofs_position(dof_pos_target)
-        self.tcp_pos = self.robot.get_tcp_position()
+        if self.control_type == "joints":
+            self.dof_pos = self.robot.get_joint_positions()
+            delta = self.actions * self.action_scale
+            dof_pos_target = self.dof_pos + delta
+            self.robot.control_dofs_position(dof_pos_target)
+            self.tcp_pos = self.robot.get_tcp_position()
+        elif self.control_type == "cartesian":
+            self.tcp_pos = self.robot.get_tcp_position()
+            delta = self.actions * self.action_scale
+            tcp_pos_target = self.tcp_pos + delta
+            tcp_ori = self.robot.get_tcp_orientation()
+            self.robot.control_tcp_position(position=tcp_pos_target, orientation=tcp_ori)
+            self.tcp_pos = self.robot.get_tcp_position()
 
         self.episode_step += 1
         self.dist = np.linalg.norm(self.tcp_pos - self.target_pos)

--- a/aegis_gym/envs/aegis_reacher.py
+++ b/aegis_gym/envs/aegis_reacher.py
@@ -81,7 +81,6 @@ class AegisReacherEnv(gym.Env):
             delta = self.actions * self.action_scale
             dof_pos_target = self.dof_pos + delta
             self.robot.control_dofs_position(dof_pos_target)
-            self.tcp_pos = self.robot.get_tcp_position()
         elif self.control_type == "cartesian":
             self.tcp_pos = self.robot.get_tcp_position()
             delta = self.actions * self.action_scale
@@ -90,7 +89,7 @@ class AegisReacherEnv(gym.Env):
             self.robot.control_tcp_position(
                 position=tcp_pos_target, orientation=tcp_ori
             )
-            self.tcp_pos = self.robot.get_tcp_position()
+        self.tcp_pos = self.robot.get_tcp_position()
 
         self.episode_step += 1
         self.dist = np.linalg.norm(self.tcp_pos - self.target_pos)

--- a/aegis_gym/envs/aegis_reacher.py
+++ b/aegis_gym/envs/aegis_reacher.py
@@ -87,7 +87,9 @@ class AegisReacherEnv(gym.Env):
             delta = self.actions * self.action_scale
             tcp_pos_target = self.tcp_pos + delta
             tcp_ori = self.robot.get_tcp_orientation()
-            self.robot.control_tcp_position(position=tcp_pos_target, orientation=tcp_ori)
+            self.robot.control_tcp_position(
+                position=tcp_pos_target, orientation=tcp_ori
+            )
             self.tcp_pos = self.robot.get_tcp_position()
 
         self.episode_step += 1

--- a/aegis_gym/scene/robot_commander_interface.py
+++ b/aegis_gym/scene/robot_commander_interface.py
@@ -47,6 +47,12 @@ class RobotCommanderInterface(ABC):
         self, target_pos: th.Tensor, max_vel: float = 0.3, max_accel: float = 0.3
     ) -> None:
         raise NotImplementedError
+    
+    @abstractmethod
+    def control_tcp_position(
+        self, target_pos: th.Tensor, target_ori: th.Tensor, max_vel: float = 0.3, max_accel: float = 0.3
+    ) -> None:
+        raise NotImplementedError
 
     @abstractmethod
     def move_to_home(self) -> None:

--- a/aegis_gym/scene/robot_commander_interface.py
+++ b/aegis_gym/scene/robot_commander_interface.py
@@ -47,10 +47,14 @@ class RobotCommanderInterface(ABC):
         self, target_pos: th.Tensor, max_vel: float = 0.3, max_accel: float = 0.3
     ) -> None:
         raise NotImplementedError
-    
+
     @abstractmethod
     def control_tcp_position(
-        self, target_pos: th.Tensor, target_ori: th.Tensor, max_vel: float = 0.3, max_accel: float = 0.3
+        self,
+        target_pos: th.Tensor,
+        target_ori: th.Tensor,
+        max_vel: float = 0.3,
+        max_accel: float = 0.3,
     ) -> None:
         raise NotImplementedError
 


### PR DESCRIPTION
## Description
This PR adds an option for the RL agent to control the UR5e in Cartesian space (TCP position) in addition to the existing joint space control mode. 


## Motivation and context
This serves as an additional control option for testing and research purposes, making it possible to compare performance and behavior of agents trained in joint space vs Cartesian space.


## How has this been tested?
In RViz by running the test script that launches the environment.


## Checklist
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [ :cactus: ] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [ :cactus: ] All automated checks have passed. -> Broken due to #5 merge in progress
---
ClickUp task: [869abnjug](https://app.clickup.com/t/869abnjug)