### PR TITLE
Add Cartesian control in Pusher environment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
         args: ["--autofix", "--no-sort-keys", "--indent", "2"]
 
 -   repo: https://github.com/python-poetry/poetry
-    rev: "2.2.0"
+    rev: "2.2.1"
     hooks:
     -   id: poetry-check
     -   id: poetry-lock
@@ -40,7 +40,7 @@ repos:
         args: [-w, --ignore-words=.codespell-ignore-words]
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.0
+    rev: v0.13.1
     hooks:
     -   id: ruff-check
         args:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [PR-17](https://github.com/AGH-CEAI/pull/17) - Added cartesian control for Reacher environment.
+- [PR-19](https://github.com/AGH-CEAI/pull/19) - Added Cartesian control for ROS robot commander.
+- [PR-17](https://github.com/AGH-CEAI/pull/17) - Added Cartesian control for Reacher environment.
 - [PR-11,12,13,14,15](https://github.com/AGH-CEAI/aegis_gym/pull/5) - Added Genesis simulator.
 - [PR-2](https://github.com/AGH-CEAI/aegis_gym/pull/2) - Added reinforcement learning Reacher environment for the Aegis robot station.
 - [PR-1](https://github.com/AGH-CEAI/aegis_gym/pull/1) - Initial package with boilerplate and gymnasium API.

--- a/aegis_gym/__init__.py
+++ b/aegis_gym/__init__.py
@@ -17,23 +17,32 @@ from .envs.env_types import (
 ENV_IDS = []
 
 tasks = ["Reacher", "Pusher"]
-obs_type = EnvObservationType.STATE.value.capitalize()
-reward_type = EnvRewardType.DENSE.value.capitalize()
-control_type = EnvControlType.JOINTS.value.capitalize()
+obs_types = [EnvObservationType.STATE]
+control_types = [EnvControlType.JOINTS, EnvControlType.CARTESIAN_POSITION]
+reward_types = [EnvRewardType.DENSE]
 
 for task in tasks:
-    env_id = f"Aegis{task}{obs_type}{control_type}{reward_type}-v1"
-    register(
-        id=env_id,
-        entry_point=f"aegis_gym.envs:Aegis{task}Env",
-        kwargs={
-            "render_mode": EnvRenderMode.NONE.value,
-            "observation_type": obs_type.lower(),
-            "control_type": control_type.lower(),
-            "reward_type": reward_type.lower(),
-            "scene_type": SceneDirectorType.ROS,
-            "device": "cuda",
-        },
-        max_episode_steps=50,
-    )
-    ENV_IDS.append(env_id)
+    for obs_type in obs_types:
+        for reward_type in reward_types:
+            for control_type in control_types:
+                env_id = (
+                    f"Aegis{task}"
+                    f"{obs_type.value.capitalize()}"
+                    f"{control_type.value.capitalize()}"
+                    f"{reward_type.value.capitalize()}"
+                    f"-v1"
+                )
+                register(
+                    id=env_id,
+                    entry_point=f"aegis_gym.envs:Aegis{task}Env",
+                    kwargs={
+                        "render_mode": EnvRenderMode.NONE.value,
+                        "observation_type": obs_type.value.lower(),
+                        "control_type": control_type.value.lower(),
+                        "reward_type": reward_type.value.lower(),
+                        "scene_type": SceneDirectorType.ROS,
+                        "device": "cuda",
+                    },
+                    max_episode_steps=50,
+                )
+                ENV_IDS.append(env_id)

--- a/aegis_gym/envs/aegis_pusher.py
+++ b/aegis_gym/envs/aegis_pusher.py
@@ -21,14 +21,13 @@ from .env_types import EnvControlType, EnvObservationType, EnvRewardType, EnvRen
 ENV_CFG = {
     "max_episode_length": 1000,
     "num_obs": 21,
-    "num_actions": 6,
     "target_pos": [-0.1, 0.76, 0.84],
     "target_threshold": 0.04,
     "object_spawn_x": [-0.36, -0.24],
     "object_spawn_y": [0.34, 0.66],
     "object_spawn_z": [0.84, 0.85],
-    "clip_action": 100.0,
-    "action_scale": 0.5,
+    "clip_action": 1,
+    "action_scale": 0.1,
     "obs_scales": {
         "dof_pos": 1.0,
         "dof_vel": 0.1,
@@ -72,10 +71,11 @@ class AegisPusherEnv(gym.Env):
         # TODO(issue#7) Rconsider episode length units unifcation for ROS and simulation
         self.max_episode_length = cfg["max_episode_length"]
         self.num_obs = cfg["num_obs"]
+        self.target_threshold = cfg["target_threshold"]
+        self.clip_action = cfg["clip_action"]
         self.obs_scales = cfg["obs_scales"]
         self.action_scale = cfg["action_scale"]
         self.reward_scales = cfg["reward_scales"]
-        self.target_threshold = cfg["target_threshold"]
 
         self.scene: SceneDirectorInterface = get_scene_director(scene_type)
         self.target: Target = self.scene.add_entity(EntityType.TARGET)
@@ -95,10 +95,10 @@ class AegisPusherEnv(gym.Env):
 
         self.episode_step = 0.0
         self.actions = th.zeros(self.num_actions, device=self.device)
-        self.last_actions = th.zeros(self.num_actions, device=self.device)
-        self.last_dof_vel = th.zeros(self.num_actions, device=self.device)
-        self.dof_pos = th.zeros(self.num_actions, device=self.device)
-        self.dof_vel = th.zeros(self.num_actions, device=self.device)
+        # self.last_actions = th.zeros(self.num_actions, device=self.device)
+        # self.last_dof_vel = th.zeros(self.num_actions, device=self.device)
+        self.dof_pos = th.zeros(6, device=self.device)
+        self.dof_vel = th.zeros(6, device=self.device)
         self.tcp_pos = th.zeros(3, device=self.device)
         # self.tcp_vel = th.zeros(3, device=self.device)
         self.object_pos = th.zeros(3, device=self.device)
@@ -120,15 +120,9 @@ class AegisPusherEnv(gym.Env):
         if isinstance(action, np.ndarray):
             action = th.from_numpy(action)
         action = action.to(self.device)
-        action = th.clamp(action, -self.cfg["clip_action"], self.cfg["clip_action"])
+        action = th.clamp(action, -self.clip_action, self.clip_action)
         self.actions = action.clone()
         delta = self.actions * self.action_scale
-
-        self.dof_pos = self.robot.get_joint_positions()
-        self.dof_vel = self.robot.get_joint_velocities()
-        self.tcp_pos = self.robot.get_tcp_position()
-        # self.tcp_vel = self.robot.get_tcp_velocity()  # If available
-        self.object_pos = self.object.get_pose()[:3].clone()
 
         if self.control_type == EnvControlType.JOINTS:
             dof_pos_target = self.dof_pos + delta
@@ -143,9 +137,10 @@ class AegisPusherEnv(gym.Env):
         self.scene.step()
         self.episode_step += 1
 
-        self.tcp_pos = self.robot.get_tcp_position()
-        dist_to_target = th.norm(self.target_pos - self.object_pos)
-        success = bool((dist_to_target < self.target_threshold).item())
+        obs = self._get_obs()
+
+        self.dist_to_target = th.norm(self.target_pos - self.object_pos)
+        success = bool(self.dist_to_target < self.target_threshold)
 
         reward = 0.0
         for name, func in self.reward_functions.items():
@@ -158,39 +153,12 @@ class AegisPusherEnv(gym.Env):
 
         self.episode_return += reward
 
-        terminated = bool(success)
         # TODO(issue#10) introduce timeouts in ROS and simulations
         # truncated = elapsed_time >= self.max_episode_length_s
+        terminated = bool(success)
         truncated = self.episode_step >= self.max_episode_length
 
-        info = {
-            "success": success,
-            "dist_to_target": dist_to_target.item(),
-            "episode_step": self.episode_step,
-            "is_truncated": truncated,
-            "is_success": success,
-        }
-
-        for key, value in self.episode_sums.items():
-            info[f"reward_{key}"] = value.item()
-
-        if terminated or truncated:
-            info["episode"] = {"r": float(reward), "l": self.episode_step}
-
-        obs = (
-            th.cat(
-                [
-                    self.dof_pos * self.obs_scales["dof_pos"],
-                    self.dof_vel * self.obs_scales["dof_vel"],
-                    self.tcp_pos,
-                    # self.tcp_vel,
-                    self.object_pos,
-                    self.target_pos,
-                ]
-            )
-            .clone()
-            .detach()
-        )
+        info = self._get_info(reward, terminated, truncated, success)
 
         return obs, reward, terminated, truncated, info
 
@@ -202,10 +170,6 @@ class AegisPusherEnv(gym.Env):
             th.manual_seed(seed)
 
         self.robot.move_to_home()
-        self.dof_pos = self.robot.get_joint_positions()
-        self.dof_vel = th.zeros_like(self.dof_vel)
-        self.tcp_pos = self.robot.get_tcp_position()
-        # self.tcp_vel = self.robot.get_tcp_velocity().float()  # If available
 
         x_range = self.cfg["object_spawn_x"]
         y_range = self.cfg["object_spawn_y"]
@@ -225,31 +189,52 @@ class AegisPusherEnv(gym.Env):
         )
 
         self.object.set_pose(rand_pose)
-        self.object_pos = self.object.get_pose()[:3].clone()
+        obs = self._get_obs()
+        self.dist_to_target = th.norm(self.tcp_pos - self.target_pos)
 
         self.actions[:] = 0.0
-        self.last_actions[:] = 0.0
-        self.last_dof_vel[:] = 0.0
+        # self.last_actions[:] = 0.0
+        # self.last_dof_vel[:] = 0.0
         self.episode_step = 0
         self.episode_return = 0.0
         self.episode_sums = {k: 0.0 for k in self.reward_functions}
 
-        obs = (
-            th.cat(
-                [
-                    self.dof_pos * self.obs_scales["dof_pos"],
-                    self.dof_vel * self.obs_scales["dof_vel"],
-                    self.tcp_pos,
-                    # self.tcp_vel,
-                    self.object_pos,
-                    self.target_pos,
-                ]
-            )
+        return obs, {}
+    
+    def _get_obs(self) -> th.Tensor:
+        self.dof_pos = self.robot.get_joint_positions()
+        self.dof_vel = self.robot.get_joint_velocities()
+        self.tcp_pos = self.robot.get_tcp_position()
+        # self.tcp_vel = self.robot.get_tcp_velocity()
+        self.object_pos = self.object.get_pose()[:3].clone()
+        return (
+            th.cat([self.dof_pos, self.dof_vel, self.tcp_pos, self.object_pos, self.target_pos])
             .clone()
             .detach()
         )
 
-        return obs, {}
+    def _get_info(
+        self,
+        reward: float = 0.0,
+        terminated: bool = False,
+        truncated: bool = False,
+        success: bool = False,
+    ) -> dict[str, Any]:
+        info = {
+            "success": success,
+            "dist_to_target": float(self.dist_to_target),
+            "episode_step": self.episode_step,
+            "is_truncated": truncated,
+            "is_success": success,
+        }
+
+        for key, value in self.episode_sums.items():
+            info[f"reward_{key}"] = float(value)
+
+        if terminated or truncated:
+            info["episode"] = {"r": float(reward), "l": self.episode_step}
+
+        return info
 
     def _reward_near(self) -> th.Tensor:
         return th.norm(self.tcp_pos - self.object_pos)

--- a/aegis_gym/envs/aegis_pusher.py
+++ b/aegis_gym/envs/aegis_pusher.py
@@ -62,11 +62,13 @@ class AegisPusherEnv(gym.Env):
         self.control_type = EnvControlType(control_type)
         self.reward_type = EnvRewardType(reward_type)
 
-        self.num_actions = None
-        if self.control_type == EnvControlType.JOINTS:
-            self.num_actions = 6
-        if self.control_type == EnvControlType.CARTESIAN_POSITION:
-            self.num_actions = 3
+        match self.control_type:
+            case EnvControlType.JOINTS:
+                self.num_actions = 6
+            case EnvControlType.CARTESIAN_POSITION:
+                self.num_actions = 3
+            case _:
+                raise ValueError(f"Unsupported control type: {self.control_type}")
 
         # TODO(issue#7) Rconsider episode length units unifcation for ROS and simulation
         self.max_episode_length = cfg["max_episode_length"]
@@ -124,15 +126,18 @@ class AegisPusherEnv(gym.Env):
         self.actions = action.clone()
         delta = self.actions * self.action_scale
 
-        if self.control_type == EnvControlType.JOINTS:
-            dof_pos_target = self.dof_pos + delta
-            self.robot.control_dofs_position(dof_pos_target)
-        elif self.control_type == EnvControlType.CARTESIAN_POSITION:
-            tcp_pos_target = self.tcp_pos + delta
-            tcp_ori = self.robot.get_tcp_orientation()
-            self.robot.control_tcp_position(
-                target_pos=tcp_pos_target, target_ori=tcp_ori
-            )
+        match self.control_type:
+            case EnvControlType.JOINTS:
+                dof_pos_target = self.dof_pos + delta
+                self.robot.control_dofs_position(dof_pos_target)
+            case EnvControlType.CARTESIAN_POSITION:
+                tcp_pos_target = self.tcp_pos + delta
+                self.robot.control_tcp_position(
+                    target_pos=tcp_pos_target,
+                    target_ori=self.robot.get_tcp_orientation(),
+                )
+            case _:
+                raise ValueError(f"Unsupported control type: {self.control_type}")
 
         self.scene.step()
         self.episode_step += 1

--- a/aegis_gym/envs/aegis_pusher.py
+++ b/aegis_gym/envs/aegis_pusher.py
@@ -139,9 +139,11 @@ class AegisPusherEnv(gym.Env):
             self.robot.control_tcp_position(
                 target_pos=tcp_pos_target, target_ori=tcp_ori
             )
+
         self.scene.step()
         self.episode_step += 1
 
+        self.tcp_pos = self.robot.get_tcp_position()
         dist_to_target = th.norm(self.target_pos - self.object_pos)
         success = bool((dist_to_target < self.target_threshold).item())
 

--- a/aegis_gym/envs/aegis_pusher.py
+++ b/aegis_gym/envs/aegis_pusher.py
@@ -97,12 +97,9 @@ class AegisPusherEnv(gym.Env):
 
         self.episode_step = 0.0
         self.actions = th.zeros(self.num_actions, device=self.device)
-        # self.last_actions = th.zeros(self.num_actions, device=self.device)
-        # self.last_dof_vel = th.zeros(self.num_actions, device=self.device)
         self.dof_pos = th.zeros(6, device=self.device)
         self.dof_vel = th.zeros(6, device=self.device)
         self.tcp_pos = th.zeros(3, device=self.device)
-        # self.tcp_vel = th.zeros(3, device=self.device)
         self.object_pos = th.zeros(3, device=self.device)
         self.target_pos = th.tensor(
             self.cfg["target_pos"], device=self.device, dtype=th.float32
@@ -152,8 +149,6 @@ class AegisPusherEnv(gym.Env):
             r = func() * self.reward_scales[name]
             self.episode_sums[name] += r
             reward += r
-        # if success:
-        #     reward += 5
         reward = float(reward.item())
 
         self.episode_return += reward
@@ -198,8 +193,6 @@ class AegisPusherEnv(gym.Env):
         self.dist_to_target = th.norm(self.tcp_pos - self.target_pos)
 
         self.actions[:] = 0.0
-        # self.last_actions[:] = 0.0
-        # self.last_dof_vel[:] = 0.0
         self.episode_step = 0
         self.episode_return = 0.0
         self.episode_sums = {k: 0.0 for k in self.reward_functions}
@@ -210,7 +203,6 @@ class AegisPusherEnv(gym.Env):
         self.dof_pos = self.robot.get_joint_positions()
         self.dof_vel = self.robot.get_joint_velocities()
         self.tcp_pos = self.robot.get_tcp_position()
-        # self.tcp_vel = self.robot.get_tcp_velocity()
         self.object_pos = self.object.get_pose()[:3].clone()
         return (
             th.cat(

--- a/aegis_gym/envs/aegis_pusher.py
+++ b/aegis_gym/envs/aegis_pusher.py
@@ -63,11 +63,17 @@ class AegisPusherEnv(gym.Env):
         self.control_type = EnvControlType(control_type)
         self.reward_type = EnvRewardType(reward_type)
 
+        self.num_actions = None
+        if self.control_type == EnvControlType.JOINTS:
+            self.num_actions = 6
+        if self.control_type == EnvControlType.CARTESIAN_POSITION:
+            self.num_actions = 3
+
         # TODO(issue#7) Rconsider episode length units unifcation for ROS and simulation
         self.max_episode_length = cfg["max_episode_length"]
-        self.num_actions = cfg["num_actions"]
         self.num_obs = cfg["num_obs"]
         self.obs_scales = cfg["obs_scales"]
+        self.action_scale = cfg["action_scale"]
         self.reward_scales = cfg["reward_scales"]
         self.target_threshold = cfg["target_threshold"]
 
@@ -116,6 +122,7 @@ class AegisPusherEnv(gym.Env):
         action = action.to(self.device)
         action = th.clamp(action, -self.cfg["clip_action"], self.cfg["clip_action"])
         self.actions = action.clone()
+        delta = self.actions * self.action_scale
 
         self.dof_pos = self.robot.get_joint_positions()
         self.dof_vel = self.robot.get_joint_velocities()
@@ -123,9 +130,15 @@ class AegisPusherEnv(gym.Env):
         # self.tcp_vel = self.robot.get_tcp_velocity()  # If available
         self.object_pos = self.object.get_pose()[:3].clone()
 
-        target_dof_pos = self.dof_pos + self.actions * self.cfg["action_scale"]
-        self.robot.control_dofs_position(target_dof_pos)
-
+        if self.control_type == EnvControlType.JOINTS:
+            dof_pos_target = self.dof_pos + delta
+            self.robot.control_dofs_position(dof_pos_target)
+        elif self.control_type == EnvControlType.CARTESIAN_POSITION:
+            tcp_pos_target = self.tcp_pos + delta
+            tcp_ori = self.robot.get_tcp_orientation()
+            self.robot.control_tcp_position(
+                target_pos=tcp_pos_target, target_ori=tcp_ori
+            )
         self.scene.step()
         self.episode_step += 1
 

--- a/aegis_gym/envs/aegis_pusher.py
+++ b/aegis_gym/envs/aegis_pusher.py
@@ -200,7 +200,7 @@ class AegisPusherEnv(gym.Env):
         self.episode_sums = {k: 0.0 for k in self.reward_functions}
 
         return obs, {}
-    
+
     def _get_obs(self) -> th.Tensor:
         self.dof_pos = self.robot.get_joint_positions()
         self.dof_vel = self.robot.get_joint_velocities()
@@ -208,7 +208,15 @@ class AegisPusherEnv(gym.Env):
         # self.tcp_vel = self.robot.get_tcp_velocity()
         self.object_pos = self.object.get_pose()[:3].clone()
         return (
-            th.cat([self.dof_pos, self.dof_vel, self.tcp_pos, self.object_pos, self.target_pos])
+            th.cat(
+                [
+                    self.dof_pos,
+                    self.dof_vel,
+                    self.tcp_pos,
+                    self.object_pos,
+                    self.target_pos,
+                ]
+            )
             .clone()
             .detach()
         )

--- a/aegis_gym/envs/aegis_reacher.py
+++ b/aegis_gym/envs/aegis_reacher.py
@@ -54,11 +54,13 @@ class AegisReacherEnv(gym.Env):
         self.control_type = EnvControlType(control_type)
         self.reward_type = EnvRewardType(reward_type)
 
-        self.num_actions = None
-        if self.control_type == EnvControlType.JOINTS:
-            self.num_actions = 6
-        if self.control_type == EnvControlType.CARTESIAN_POSITION:
-            self.num_actions = 3
+        match self.control_type:
+            case EnvControlType.JOINTS:
+                self.num_actions = 6
+            case EnvControlType.CARTESIAN_POSITION:
+                self.num_actions = 3
+            case _:
+                raise ValueError(f"Unsupported control type: {self.control_type}")
 
         # TODO(issue#7) Rconsider episode length units unifcation for ROS and simulation
         self.max_episode_length = cfg["max_episode_length"]
@@ -110,15 +112,18 @@ class AegisReacherEnv(gym.Env):
         self.actions = action.clone()
         delta = self.actions * self.action_scale
 
-        if self.control_type == EnvControlType.JOINTS:
-            dof_pos_target = self.dof_pos + delta
-            self.robot.control_dofs_position(dof_pos_target)
-        elif self.control_type == EnvControlType.CARTESIAN_POSITION:
-            tcp_pos_target = self.tcp_pos + delta
-            tcp_ori = self.robot.get_tcp_orientation()
-            self.robot.control_tcp_position(
-                target_pos=tcp_pos_target, target_ori=tcp_ori
-            )
+        match self.control_type:
+            case EnvControlType.JOINTS:
+                dof_pos_target = self.dof_pos + delta
+                self.robot.control_dofs_position(dof_pos_target)
+            case EnvControlType.CARTESIAN_POSITION:
+                tcp_pos_target = self.tcp_pos + delta
+                self.robot.control_tcp_position(
+                    target_pos=tcp_pos_target,
+                    target_ori=self.robot.get_tcp_orientation(),
+                )
+            case _:
+                raise ValueError(f"Unsupported control type: {self.control_type}")
 
         self.scene.step()
         self.episode_step += 1

--- a/aegis_gym/envs/aegis_reacher.py
+++ b/aegis_gym/envs/aegis_reacher.py
@@ -108,24 +108,25 @@ class AegisReacherEnv(gym.Env):
         action = action.to(self.device)
         action = th.clamp(action, -self.clip_action, self.clip_action)
         self.actions = action.clone()
+        delta = self.actions * self.action_scale
+
+        self.dof_pos = self.robot.get_joint_positions()
+        self.tcp_pos = self.robot.get_tcp_position()
 
         if self.control_type == EnvControlType.JOINTS:
-            self.dof_pos = self.robot.get_joint_positions()
-            delta = self.actions * self.action_scale
             dof_pos_target = self.dof_pos + delta
             self.robot.control_dofs_position(dof_pos_target)
         elif self.control_type == EnvControlType.CARTESIAN_POSITION:
-            self.tcp_pos = self.robot.get_tcp_position()
-            delta = self.actions * self.action_scale
             tcp_pos_target = self.tcp_pos + delta
             tcp_ori = self.robot.get_tcp_orientation()
             self.robot.control_tcp_position(
                 target_pos=tcp_pos_target, target_ori=tcp_ori
             )
-        self.scene.step()
-        self.tcp_pos = self.robot.get_tcp_position()
 
+        self.scene.step()
         self.episode_step += 1
+
+        self.tcp_pos = self.robot.get_tcp_position()
         self.dist = th.norm(self.tcp_pos - self.target_pos)
         success = bool(self.dist < self.target_threshold)
 

--- a/aegis_gym/envs/aegis_reacher.py
+++ b/aegis_gym/envs/aegis_reacher.py
@@ -110,9 +110,6 @@ class AegisReacherEnv(gym.Env):
         self.actions = action.clone()
         delta = self.actions * self.action_scale
 
-        self.dof_pos = self.robot.get_joint_positions()
-        self.tcp_pos = self.robot.get_tcp_position()
-
         if self.control_type == EnvControlType.JOINTS:
             dof_pos_target = self.dof_pos + delta
             self.robot.control_dofs_position(dof_pos_target)
@@ -126,9 +123,10 @@ class AegisReacherEnv(gym.Env):
         self.scene.step()
         self.episode_step += 1
 
-        self.tcp_pos = self.robot.get_tcp_position()
-        self.dist = th.norm(self.tcp_pos - self.target_pos)
-        success = bool(self.dist < self.target_threshold)
+        obs = self._get_obs()
+
+        self.dist_to_target = th.norm(self.tcp_pos - self.target_pos)
+        success = bool(self.dist_to_target < self.target_threshold)
 
         reward = 0.0
         for name, func in self.reward_functions.items():
@@ -141,11 +139,12 @@ class AegisReacherEnv(gym.Env):
 
         # TODO(issue#10) introduce timeouts in ROS and simulations
         # truncated = elapsed_time >= self.max_episode_length_s
-        truncated = self.episode_step >= self.max_episode_length
         terminated = bool(success)
+        truncated = self.episode_step >= self.max_episode_length
+
         info = self._get_info(reward, terminated, truncated, success)
 
-        return self._get_obs(), reward, terminated, truncated, info
+        return obs, reward, terminated, truncated, info
 
     def reset(
         self, seed: Optional[int] = None, options: Optional[dict] = None
@@ -172,15 +171,16 @@ class AegisReacherEnv(gym.Env):
             )
         )
 
+        obs = self._get_obs()
+        self.dist_to_target = th.norm(self.tcp_pos - self.target_pos)
+
         self.actions[:] = 0.0
         self.episode_step = 0
         self.episode_return = 0.0
         self.episode_sums = {k: 0.0 for k in self.reward_functions}
-        self.tcp_pos = self.robot.get_tcp_position()
-        self.dist = th.norm(self.tcp_pos - self.target_pos)
         self.episode_start_time = time.time()
 
-        return self._get_obs(), self._get_info()
+        return obs, {}
 
     def _get_obs(self) -> th.Tensor:
         self.dof_pos = self.robot.get_joint_positions()
@@ -201,7 +201,7 @@ class AegisReacherEnv(gym.Env):
     ) -> dict[str, Any]:
         info = {
             "success": success,
-            "dist_to_target": float(self.dist),
+            "dist_to_target": float(self.dist_to_target),
             "episode_step": self.episode_step,
             "is_truncated": truncated,
             "is_success": success,
@@ -216,7 +216,7 @@ class AegisReacherEnv(gym.Env):
         return info
 
     def _reward_dist(self) -> float:
-        return float(self.dist)
+        return float(self.dist_to_target)
 
     def _reward_control(self) -> float:
         return float(th.sum(self.actions**2))

--- a/aegis_gym/ros/robot_commander_ros.py
+++ b/aegis_gym/ros/robot_commander_ros.py
@@ -78,7 +78,18 @@ class RobotCommanderROS(RobotCommanderInterface):
         max_vel: float = 0.3,
         max_accel: float = 0.3,
     ) -> None:
-        raise NotImplementedError
+        pos_np = target_pos.detach().cpu().numpy()
+        ori_np = target_ori.detach().cpu().numpy()
+
+        pos_tuple = tuple(float(v) for v in pos_np)
+        ori_tuple = tuple(float(v) for v in ori_np)
+
+        self.robot_director.pose_move(
+            position=pos_tuple,
+            quat_xyzw=ori_tuple,
+            max_vel=max_vel,
+            max_accel=max_accel,
+        )
 
     def move_to_home(self) -> None:
         self.robot_director.joint_move(

--- a/aegis_gym/ros/robot_commander_ros.py
+++ b/aegis_gym/ros/robot_commander_ros.py
@@ -64,11 +64,11 @@ class RobotCommanderROS(RobotCommanderInterface):
         self, target_pos: th.Tensor, max_vel: float = 0.3, max_accel: float = 0.3
     ) -> None:
         target_pos_np = target_pos.detach().cpu().numpy()
-        joint_dict = {
+        target_pos_dict = {
             name: float(pos) for name, pos in zip(self.joint_names, target_pos_np)
         }
         self.robot_director.joint_move(
-            joint_positions=joint_dict, max_vel=max_vel, max_accel=max_accel
+            joint_positions=target_pos_dict, max_vel=max_vel, max_accel=max_accel
         )
 
     def control_tcp_position(
@@ -78,15 +78,15 @@ class RobotCommanderROS(RobotCommanderInterface):
         max_vel: float = 0.3,
         max_accel: float = 0.3,
     ) -> None:
-        pos_np = target_pos.detach().cpu().numpy()
-        ori_np = target_ori.detach().cpu().numpy()
+        target_pos_np = target_pos.detach().cpu().numpy()
+        target_ori_np = target_ori.detach().cpu().numpy()
 
-        pos_tuple = tuple(float(v) for v in pos_np)
-        ori_tuple = tuple(float(v) for v in ori_np)
+        target_pos_tuple = tuple(float(v) for v in target_pos_np)
+        target_ori_tuple = tuple(float(v) for v in target_ori_np)
 
         self.robot_director.pose_move(
-            position=pos_tuple,
-            quat_xyzw=ori_tuple,
+            position=target_pos_tuple,
+            quat_xyzw=target_ori_tuple,
             max_vel=max_vel,
             max_accel=max_accel,
         )

--- a/aegis_gym/sim/genesis/__init__.py
+++ b/aegis_gym/sim/genesis/__init__.py
@@ -16,25 +16,34 @@ from ...envs.env_types import (
 
 ENV_IDS = []
 
-tasks = ["Reacher", "Pusher"]
 sim_name = SceneDirectorType.SIM_GENESIS.value
-obs_type = EnvObservationType.STATE.value.capitalize()
-reward_type = EnvRewardType.DENSE.value.capitalize()
-control_type = EnvControlType.JOINTS.value.capitalize()
+tasks = ["Reacher", "Pusher"]
+obs_types = [EnvObservationType.STATE]
+control_types = [EnvControlType.JOINTS, EnvControlType.CARTESIAN_POSITION]
+reward_types = [EnvRewardType.DENSE]
 
 for task in tasks:
-    env_id = f"Aegis{sim_name}{obs_type}{task}{control_type}{reward_type}-v1"
-    register(
-        id=env_id,
-        entry_point=f"aegis_gym.envs:Aegis{task}Env",
-        kwargs={
-            "render_mode": EnvRenderMode.NONE.value,
-            "observation_type": obs_type.lower(),
-            "control_type": control_type.lower(),
-            "reward_type": reward_type.lower(),
-            "scene_type": SceneDirectorType.SIM_GENESIS,
-            "device": "cuda",
-        },
-        max_episode_steps=50,
-    )
-    ENV_IDS.append(env_id)
+    for obs_type in obs_types:
+        for reward_type in reward_types:
+            for control_type in control_types:
+                env_id = (
+                    f"Aegis{sim_name}{task}"
+                    f"{obs_type.value.capitalize()}"
+                    f"{control_type.value.capitalize()}"
+                    f"{reward_type.value.capitalize()}"
+                    f"-v1"
+                )
+                register(
+                    id=env_id,
+                    entry_point=f"aegis_gym.envs:Aegis{task}Env",
+                    kwargs={
+                        "render_mode": EnvRenderMode.NONE.value,
+                        "observation_type": obs_type.value.lower(),
+                        "control_type": control_type.value.lower(),
+                        "reward_type": reward_type.value.lower(),
+                        "scene_type": SceneDirectorType.SIM_GENESIS,
+                        "device": "cuda",
+                    },
+                    max_episode_steps=50,
+                )
+                ENV_IDS.append(env_id)

--- a/test/sb3_run_train.py
+++ b/test/sb3_run_train.py
@@ -3,6 +3,7 @@ import time
 import gymnasium as gym
 
 import aegis_gym
+import aegis_gym.sim.genesis as sim_genesis
 from aegis_gym.sim.utils import TorchToNumpyWrapper
 
 try:

--- a/test/sb3_run_train.py
+++ b/test/sb3_run_train.py
@@ -3,7 +3,6 @@ import time
 import gymnasium as gym
 
 import aegis_gym
-import aegis_gym.sim.genesis as sim_genesis
 from aegis_gym.sim.utils import TorchToNumpyWrapper
 
 try:
@@ -16,8 +15,8 @@ except ImportError:
 
 
 def main():
-    env_name = sim_genesis.ENV_IDS[0]
-    # env_name = aegis_gym.ENV_IDS[0]
+    env_name = aegis_gym.ENV_IDS[0]
+    # env_name = sim_genesis.ENV_IDS[0]
 
     print(f"Training on environment: {env_name}")
 

--- a/test/sb3_run_train.py
+++ b/test/sb3_run_train.py
@@ -3,7 +3,7 @@ import time
 import gymnasium as gym
 
 import aegis_gym
-import aegis_gym.sim.genesis as sim_genesis
+import aegis_gym.sim.genesis as sim_genesis  # noqa: F401
 from aegis_gym.sim.utils import TorchToNumpyWrapper
 
 try:

--- a/test/sb3_run_train.py
+++ b/test/sb3_run_train.py
@@ -3,6 +3,7 @@ import time
 import gymnasium as gym
 
 import aegis_gym
+import aegis_gym.sim.genesis as sim_genesis
 from aegis_gym.sim.utils import TorchToNumpyWrapper
 
 try:
@@ -15,8 +16,8 @@ except ImportError:
 
 
 def main():
-    # env_name = sim_genesis.ENV_IDS[0]
-    env_name = aegis_gym.ENV_IDS[0]
+    env_name = sim_genesis.ENV_IDS[0]
+    # env_name = aegis_gym.ENV_IDS[0]
 
     print(f"Training on environment: {env_name}")
 


### PR DESCRIPTION
## Description
This PR adds an option for the RL agent to control the UR5e in Cartesian space (TCP position) in addition to the existing joint space control mode.


## Motivation and context
This serves as an additional control option for testing and research purposes, making it possible to compare performance and behavior of agents trained in joint space vs Cartesian space.


## How has this been tested?
* Both with ROS `mock_hardwareL=true` and in Genesis Sim

## Checklist
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [ :cactus: ] All automated checks have passed.