### PR TITLE
Implement Cartesian control for Genesis robot commander

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
         args: [-w, --ignore-words=.codespell-ignore-words]
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.3
+    rev: v0.14.0
     hooks:
     -   id: ruff-check
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
         args: [-w, --ignore-words=.codespell-ignore-words]
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.1
+    rev: v0.13.3
     hooks:
     -   id: ruff-check
         args:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [PR-21](https://github.com/AGH-CEAI/pull/21) - Added Cartesian control for Genesis robot commander.
 - [PR-19](https://github.com/AGH-CEAI/pull/19) - Added Cartesian control for ROS robot commander.
 - [PR-17](https://github.com/AGH-CEAI/pull/17) - Added Cartesian control for Reacher environment.
 - [PR-11,12,13,14,15](https://github.com/AGH-CEAI/aegis_gym/pull/5) - Added Genesis simulator.
@@ -17,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [PR-21](https://github.com/AGH-CEAI/aegis_gym/pull/21) - Changed robot PD gains in Genesis.
+- [PR-21](https://github.com/AGH-CEAI/aegis_gym/pull/21) - Differentiated between synchronous and asynchronous control methods.
 - [PR-11,12,13,14,15](https://github.com/AGH-CEAI/aegis_gym/pull/5) - REFACTOR: Abstract interfaces for Genesis sim and ROS control.
 - [PR-4](https://github.com/AGH-CEAI/aegis_gym/pull/4) - Updated & fixed dependencies versions.
 
@@ -27,5 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+
+- [PR-21](https://github.com/AGH-CEAI/aegis_gym/pull/21) - Fixed TCP link handling in Genesis.
 
 ### Security

--- a/aegis_gym/__init__.py
+++ b/aegis_gym/__init__.py
@@ -18,7 +18,12 @@ ENV_IDS = []
 
 tasks = ["Reacher", "Pusher"]
 obs_types = [EnvObservationType.STATE]
-control_types = [EnvControlType.JOINTS, EnvControlType.JOINTS_SERVO, EnvControlType.CARTESIAN_POSITION, EnvControlType.CARTESIAN_POSITION_SERVO]
+control_types = [
+    EnvControlType.JOINTS,
+    EnvControlType.JOINTS_SERVO,
+    EnvControlType.CARTESIAN_POSITION,
+    EnvControlType.CARTESIAN_POSITION_SERVO,
+]
 reward_types = [EnvRewardType.DENSE]
 
 for task in tasks:

--- a/aegis_gym/__init__.py
+++ b/aegis_gym/__init__.py
@@ -18,7 +18,7 @@ ENV_IDS = []
 
 tasks = ["Reacher", "Pusher"]
 obs_types = [EnvObservationType.STATE]
-control_types = [EnvControlType.JOINTS, EnvControlType.CARTESIAN_POSITION]
+control_types = [EnvControlType.JOINTS, EnvControlType.JOINTS_SERVO, EnvControlType.CARTESIAN_POSITION, EnvControlType.CARTESIAN_POSITION_SERVO]
 reward_types = [EnvRewardType.DENSE]
 
 for task in tasks:

--- a/aegis_gym/envs/aegis_pusher.py
+++ b/aegis_gym/envs/aegis_pusher.py
@@ -55,6 +55,7 @@ class AegisPusherEnv(gym.Env):
     ) -> None:
         super().__init__()
         self.cfg = cfg
+        self.scene_type = scene_type
         self.device = device
 
         self.render_mode = EnvRenderMode(render_mode)
@@ -63,9 +64,9 @@ class AegisPusherEnv(gym.Env):
         self.reward_type = EnvRewardType(reward_type)
 
         match self.control_type:
-            case EnvControlType.JOINTS:
+            case EnvControlType.JOINTS | EnvControlType.JOINTS_SERVO:
                 self.num_actions = 6
-            case EnvControlType.CARTESIAN_POSITION:
+            case EnvControlType.CARTESIAN_POSITION | EnvControlType.CARTESIAN_POSITION_SERVO:
                 self.num_actions = 3
             case _:
                 raise ValueError(f"Unsupported control type: {self.control_type}")
@@ -127,11 +128,44 @@ class AegisPusherEnv(gym.Env):
             case EnvControlType.JOINTS:
                 dof_pos_target = self.dof_pos + delta
                 self.robot.control_dofs_position(dof_pos_target)
+            case EnvControlType.JOINTS_SERVO:
+                dof_pos_target = self.dof_pos + delta
+                self.robot.control_dofs_position_servo(dof_pos_target)
             case EnvControlType.CARTESIAN_POSITION:
                 tcp_pos_target = self.tcp_pos + delta
+                if self.scene_type == SceneDirectorType.SIM_GENESIS:
+                    tcp_ori_target = th.tensor(
+                        [0.0, 0.7071, 0.7071, 0.0],
+                        dtype=th.float32,
+                        device=self.device,
+                    )
+                else:
+                    tcp_ori_target = th.tensor(
+                        [1.0, 0.0, 0.0, 0.0],
+                        dtype=th.float32,
+                        device=self.device,
+                    )
                 self.robot.control_tcp_position(
                     target_pos=tcp_pos_target,
-                    target_ori=self.robot.get_tcp_orientation(),
+                    target_ori=tcp_ori_target,
+                )
+            case EnvControlType.CARTESIAN_POSITION_SERVO:
+                tcp_pos_target = self.tcp_pos + delta
+                if self.scene_type == SceneDirectorType.SIM_GENESIS:
+                    tcp_ori_target = th.tensor(
+                        [0.0, 0.7071, 0.7071, 0.0],
+                        dtype=th.float32,
+                        device=self.device,
+                    )
+                else:
+                    tcp_ori_target = th.tensor(
+                        [1.0, 0.0, 0.0, 0.0],
+                        dtype=th.float32,
+                        device=self.device,
+                    )
+                self.robot.control_tcp_position_servo(
+                    target_pos=tcp_pos_target,
+                    target_ori=tcp_ori_target,
                 )
             case _:
                 raise ValueError(f"Unsupported control type: {self.control_type}")

--- a/aegis_gym/envs/aegis_pusher.py
+++ b/aegis_gym/envs/aegis_pusher.py
@@ -66,7 +66,10 @@ class AegisPusherEnv(gym.Env):
         match self.control_type:
             case EnvControlType.JOINTS | EnvControlType.JOINTS_SERVO:
                 self.num_actions = 6
-            case EnvControlType.CARTESIAN_POSITION | EnvControlType.CARTESIAN_POSITION_SERVO:
+            case (
+                EnvControlType.CARTESIAN_POSITION
+                | EnvControlType.CARTESIAN_POSITION_SERVO
+            ):
                 self.num_actions = 3
             case _:
                 raise ValueError(f"Unsupported control type: {self.control_type}")

--- a/aegis_gym/envs/aegis_pusher.py
+++ b/aegis_gym/envs/aegis_pusher.py
@@ -55,7 +55,6 @@ class AegisPusherEnv(gym.Env):
     ) -> None:
         super().__init__()
         self.cfg = cfg
-        self.scene_type = scene_type
         self.device = device
 
         self.render_mode = EnvRenderMode(render_mode)
@@ -136,40 +135,10 @@ class AegisPusherEnv(gym.Env):
                 self.robot.control_dofs_position_servo(dof_pos_target)
             case EnvControlType.CARTESIAN_POSITION:
                 tcp_pos_target = self.tcp_pos + delta
-                if self.scene_type == SceneDirectorType.SIM_GENESIS:
-                    tcp_ori_target = th.tensor(
-                        [0.0, 0.7071, 0.7071, 0.0],
-                        dtype=th.float32,
-                        device=self.device,
-                    )
-                else:
-                    tcp_ori_target = th.tensor(
-                        [1.0, 0.0, 0.0, 0.0],
-                        dtype=th.float32,
-                        device=self.device,
-                    )
-                self.robot.control_tcp_position(
-                    target_pos=tcp_pos_target,
-                    target_ori=tcp_ori_target,
-                )
+                self.robot.control_tcp_position(target_pos=tcp_pos_target)
             case EnvControlType.CARTESIAN_POSITION_SERVO:
                 tcp_pos_target = self.tcp_pos + delta
-                if self.scene_type == SceneDirectorType.SIM_GENESIS:
-                    tcp_ori_target = th.tensor(
-                        [0.0, 0.7071, 0.7071, 0.0],
-                        dtype=th.float32,
-                        device=self.device,
-                    )
-                else:
-                    tcp_ori_target = th.tensor(
-                        [1.0, 0.0, 0.0, 0.0],
-                        dtype=th.float32,
-                        device=self.device,
-                    )
-                self.robot.control_tcp_position_servo(
-                    target_pos=tcp_pos_target,
-                    target_ori=tcp_ori_target,
-                )
+                self.robot.control_tcp_position_servo(target_pos=tcp_pos_target)
             case _:
                 raise ValueError(f"Unsupported control type: {self.control_type}")
 

--- a/aegis_gym/envs/aegis_reacher.py
+++ b/aegis_gym/envs/aegis_reacher.py
@@ -58,7 +58,10 @@ class AegisReacherEnv(gym.Env):
         match self.control_type:
             case EnvControlType.JOINTS | EnvControlType.JOINTS_SERVO:
                 self.num_actions = 6
-            case EnvControlType.CARTESIAN_POSITION | EnvControlType.CARTESIAN_POSITION_SERVO:
+            case (
+                EnvControlType.CARTESIAN_POSITION
+                | EnvControlType.CARTESIAN_POSITION_SERVO
+            ):
                 self.num_actions = 3
             case _:
                 raise ValueError(f"Unsupported control type: {self.control_type}")

--- a/aegis_gym/envs/aegis_reacher.py
+++ b/aegis_gym/envs/aegis_reacher.py
@@ -47,6 +47,7 @@ class AegisReacherEnv(gym.Env):
     ) -> None:
         super().__init__()
         self.cfg = cfg
+        self.scene_type = scene_type
         self.device = device
 
         self.render_mode = EnvRenderMode(render_mode)
@@ -55,9 +56,9 @@ class AegisReacherEnv(gym.Env):
         self.reward_type = EnvRewardType(reward_type)
 
         match self.control_type:
-            case EnvControlType.JOINTS:
+            case EnvControlType.JOINTS | EnvControlType.JOINTS_SERVO:
                 self.num_actions = 6
-            case EnvControlType.CARTESIAN_POSITION:
+            case EnvControlType.CARTESIAN_POSITION | EnvControlType.CARTESIAN_POSITION_SERVO:
                 self.num_actions = 3
             case _:
                 raise ValueError(f"Unsupported control type: {self.control_type}")
@@ -116,11 +117,44 @@ class AegisReacherEnv(gym.Env):
             case EnvControlType.JOINTS:
                 dof_pos_target = self.dof_pos + delta
                 self.robot.control_dofs_position(dof_pos_target)
+            case EnvControlType.JOINTS_SERVO:
+                dof_pos_target = self.dof_pos + delta
+                self.robot.control_dofs_position_servo(dof_pos_target)
             case EnvControlType.CARTESIAN_POSITION:
                 tcp_pos_target = self.tcp_pos + delta
+                if self.scene_type == SceneDirectorType.SIM_GENESIS:
+                    tcp_ori_target = th.tensor(
+                        [0.0, 0.7071, 0.7071, 0.0],
+                        dtype=th.float32,
+                        device=self.device,
+                    )
+                else:
+                    tcp_ori_target = th.tensor(
+                        [1.0, 0.0, 0.0, 0.0],
+                        dtype=th.float32,
+                        device=self.device,
+                    )
                 self.robot.control_tcp_position(
                     target_pos=tcp_pos_target,
-                    target_ori=self.robot.get_tcp_orientation(),
+                    target_ori=tcp_ori_target,
+                )
+            case EnvControlType.CARTESIAN_POSITION_SERVO:
+                tcp_pos_target = self.tcp_pos + delta
+                if self.scene_type == SceneDirectorType.SIM_GENESIS:
+                    tcp_ori_target = th.tensor(
+                        [0.0, 0.7071, 0.7071, 0.0],
+                        dtype=th.float32,
+                        device=self.device,
+                    )
+                else:
+                    tcp_ori_target = th.tensor(
+                        [1.0, 0.0, 0.0, 0.0],
+                        dtype=th.float32,
+                        device=self.device,
+                    )
+                self.robot.control_tcp_position_servo(
+                    target_pos=tcp_pos_target,
+                    target_ori=tcp_ori_target,
                 )
             case _:
                 raise ValueError(f"Unsupported control type: {self.control_type}")

--- a/aegis_gym/envs/aegis_reacher.py
+++ b/aegis_gym/envs/aegis_reacher.py
@@ -47,7 +47,6 @@ class AegisReacherEnv(gym.Env):
     ) -> None:
         super().__init__()
         self.cfg = cfg
-        self.scene_type = scene_type
         self.device = device
 
         self.render_mode = EnvRenderMode(render_mode)
@@ -125,40 +124,10 @@ class AegisReacherEnv(gym.Env):
                 self.robot.control_dofs_position_servo(dof_pos_target)
             case EnvControlType.CARTESIAN_POSITION:
                 tcp_pos_target = self.tcp_pos + delta
-                if self.scene_type == SceneDirectorType.SIM_GENESIS:
-                    tcp_ori_target = th.tensor(
-                        [0.0, 0.7071, 0.7071, 0.0],
-                        dtype=th.float32,
-                        device=self.device,
-                    )
-                else:
-                    tcp_ori_target = th.tensor(
-                        [1.0, 0.0, 0.0, 0.0],
-                        dtype=th.float32,
-                        device=self.device,
-                    )
-                self.robot.control_tcp_position(
-                    target_pos=tcp_pos_target,
-                    target_ori=tcp_ori_target,
-                )
+                self.robot.control_tcp_position(target_pos=tcp_pos_target)
             case EnvControlType.CARTESIAN_POSITION_SERVO:
                 tcp_pos_target = self.tcp_pos + delta
-                if self.scene_type == SceneDirectorType.SIM_GENESIS:
-                    tcp_ori_target = th.tensor(
-                        [0.0, 0.7071, 0.7071, 0.0],
-                        dtype=th.float32,
-                        device=self.device,
-                    )
-                else:
-                    tcp_ori_target = th.tensor(
-                        [1.0, 0.0, 0.0, 0.0],
-                        dtype=th.float32,
-                        device=self.device,
-                    )
-                self.robot.control_tcp_position_servo(
-                    target_pos=tcp_pos_target,
-                    target_ori=tcp_ori_target,
-                )
+                self.robot.control_tcp_position_servo(target_pos=tcp_pos_target)
             case _:
                 raise ValueError(f"Unsupported control type: {self.control_type}")
 

--- a/aegis_gym/envs/env_types.py
+++ b/aegis_gym/envs/env_types.py
@@ -20,5 +20,8 @@ class EnvObservationType(LowercaseStrEnum):
 
 class EnvControlType(LowercaseStrEnum):
     JOINTS = auto()
+    JOINTS_SERVO = auto()
     CARTESIAN_POSITION = auto()
+    CARTESIAN_POSITION_SERVO = auto()
     CARTESIAN_POSE = auto()
+    CARTESIAN_POSE_SERVO = auto()

--- a/aegis_gym/ros/robot_commander_ros.py
+++ b/aegis_gym/ros/robot_commander_ros.py
@@ -71,6 +71,11 @@ class RobotCommanderROS(RobotCommanderInterface):
             joint_positions=target_pos_dict, max_vel=max_vel, max_accel=max_accel
         )
 
+    def control_dofs_position_servo(
+        self, target_pos: th.Tensor, max_vel: float = 0.3, max_accel: float = 0.3
+    ) -> None:
+        pass
+
     def control_tcp_position(
         self,
         target_pos: th.Tensor,
@@ -90,6 +95,15 @@ class RobotCommanderROS(RobotCommanderInterface):
             max_vel=max_vel,
             max_accel=max_accel,
         )
+
+    def control_tcp_position_servo(
+        self,
+        target_pos: th.Tensor,
+        target_ori: th.Tensor,
+        max_vel: float = 0.3,
+        max_accel: float = 0.3,
+    ) -> None:
+        pass
 
     def move_to_home(self) -> None:
         self.robot_director.joint_move(

--- a/aegis_gym/ros/robot_commander_ros.py
+++ b/aegis_gym/ros/robot_commander_ros.py
@@ -71,10 +71,12 @@ class RobotCommanderROS(RobotCommanderInterface):
             joint_positions=target_pos_dict, max_vel=max_vel, max_accel=max_accel
         )
 
+    # TODO(issue#22): Implement continous control for ROS robot commander
+
     def control_dofs_position_servo(
         self, target_pos: th.Tensor, max_vel: float = 0.3, max_accel: float = 0.3
     ) -> None:
-        pass
+        raise NotImplementedError
 
     def control_tcp_position(
         self,
@@ -103,7 +105,7 @@ class RobotCommanderROS(RobotCommanderInterface):
         max_vel: float = 0.3,
         max_accel: float = 0.3,
     ) -> None:
-        pass
+        raise NotImplementedError
 
     def move_to_home(self) -> None:
         self.robot_director.joint_move(

--- a/aegis_gym/ros/robot_commander_ros.py
+++ b/aegis_gym/ros/robot_commander_ros.py
@@ -71,7 +71,7 @@ class RobotCommanderROS(RobotCommanderInterface):
             joint_positions=target_pos_dict, max_vel=max_vel, max_accel=max_accel
         )
 
-    # TODO(issue#22): Implement continous control for ROS robot commander
+    # TODO(issue#22): Implement continuous control for ROS robot commander
 
     def control_dofs_position_servo(
         self, target_pos: th.Tensor, max_vel: float = 0.3, max_accel: float = 0.3
@@ -81,10 +81,17 @@ class RobotCommanderROS(RobotCommanderInterface):
     def control_tcp_position(
         self,
         target_pos: th.Tensor,
-        target_ori: th.Tensor,
+        target_ori: th.Tensor | None = None,
         max_vel: float = 0.3,
         max_accel: float = 0.3,
     ) -> None:
+        if target_ori is None:
+            target_ori = th.tensor(
+                [1.0, 0.0, 0.0, 0.0],
+                dtype=th.float32,
+                device=self.device,
+            )
+
         target_pos_np = target_pos.detach().cpu().numpy()
         target_ori_np = target_ori.detach().cpu().numpy()
 

--- a/aegis_gym/ros/robot_commander_ros.py
+++ b/aegis_gym/ros/robot_commander_ros.py
@@ -72,7 +72,6 @@ class RobotCommanderROS(RobotCommanderInterface):
         )
 
     # TODO(issue#22): Implement continuous control for ROS robot commander
-
     def control_dofs_position_servo(
         self, target_pos: th.Tensor, max_vel: float = 0.3, max_accel: float = 0.3
     ) -> None:
@@ -105,6 +104,7 @@ class RobotCommanderROS(RobotCommanderInterface):
             max_accel=max_accel,
         )
 
+    # TODO(issue#22): Implement continuous control for ROS robot commander
     def control_tcp_position_servo(
         self,
         target_pos: th.Tensor,

--- a/aegis_gym/scene/robot_commander_interface.py
+++ b/aegis_gym/scene/robot_commander_interface.py
@@ -47,9 +47,24 @@ class RobotCommanderInterface(ABC):
         self, target_pos: th.Tensor, max_vel: float = 0.3, max_accel: float = 0.3
     ) -> None:
         raise NotImplementedError
+    
+    def control_dofs_position_servo(
+        self, target_pos: th.Tensor, max_vel: float = 0.3, max_accel: float = 0.3
+    ) -> None:
+        raise NotImplementedError
 
     @abstractmethod
     def control_tcp_position(
+        self,
+        target_pos: th.Tensor,
+        target_ori: th.Tensor,
+        max_vel: float = 0.3,
+        max_accel: float = 0.3,
+    ) -> None:
+        raise NotImplementedError
+    
+    @abstractmethod
+    def control_tcp_position_servo(
         self,
         target_pos: th.Tensor,
         target_ori: th.Tensor,

--- a/aegis_gym/scene/robot_commander_interface.py
+++ b/aegis_gym/scene/robot_commander_interface.py
@@ -47,7 +47,7 @@ class RobotCommanderInterface(ABC):
         self, target_pos: th.Tensor, max_vel: float = 0.3, max_accel: float = 0.3
     ) -> None:
         raise NotImplementedError
-    
+
     def control_dofs_position_servo(
         self, target_pos: th.Tensor, max_vel: float = 0.3, max_accel: float = 0.3
     ) -> None:
@@ -62,7 +62,7 @@ class RobotCommanderInterface(ABC):
         max_accel: float = 0.3,
     ) -> None:
         raise NotImplementedError
-    
+
     @abstractmethod
     def control_tcp_position_servo(
         self,

--- a/aegis_gym/sim/genesis/__init__.py
+++ b/aegis_gym/sim/genesis/__init__.py
@@ -19,7 +19,7 @@ ENV_IDS = []
 sim_name = SceneDirectorType.SIM_GENESIS.value
 tasks = ["Reacher", "Pusher"]
 obs_types = [EnvObservationType.STATE]
-control_types = [EnvControlType.JOINTS, EnvControlType.CARTESIAN_POSITION]
+control_types = [EnvControlType.JOINTS, EnvControlType.JOINTS_SERVO, EnvControlType.CARTESIAN_POSITION, EnvControlType.CARTESIAN_POSITION_SERVO]
 reward_types = [EnvRewardType.DENSE]
 
 for task in tasks:

--- a/aegis_gym/sim/genesis/__init__.py
+++ b/aegis_gym/sim/genesis/__init__.py
@@ -19,7 +19,12 @@ ENV_IDS = []
 sim_name = SceneDirectorType.SIM_GENESIS.value
 tasks = ["Reacher", "Pusher"]
 obs_types = [EnvObservationType.STATE]
-control_types = [EnvControlType.JOINTS, EnvControlType.JOINTS_SERVO, EnvControlType.CARTESIAN_POSITION, EnvControlType.CARTESIAN_POSITION_SERVO]
+control_types = [
+    EnvControlType.JOINTS,
+    EnvControlType.JOINTS_SERVO,
+    EnvControlType.CARTESIAN_POSITION,
+    EnvControlType.CARTESIAN_POSITION_SERVO,
+]
 reward_types = [EnvRewardType.DENSE]
 
 for task in tasks:

--- a/aegis_gym/sim/genesis/robot_commander_genesis.py
+++ b/aegis_gym/sim/genesis/robot_commander_genesis.py
@@ -29,12 +29,13 @@ class RobotCommanderSimGenesis(RobotCommanderInterface):
         ori = self.get_tcp_orientation()
         return th.cat([pos, ori])
 
-    # TODO(issue#9) use max cel and accel
+    # TODO(issue#9): Limit velocity and acceleration for Genesis robot commander
+    # TODO(issue#23): Implement synchronous control for Genesis robot commander
 
     def control_dofs_position(
         self, target_pos: th.Tensor, max_vel: float = 0.3, max_accel: float = 0.3
     ) -> None:
-        pass
+        raise NotImplementedError
 
     def control_dofs_position_servo(
         self, target_pos: th.Tensor, max_vel: float = 0.3, max_accel: float = 0.3
@@ -48,7 +49,7 @@ class RobotCommanderSimGenesis(RobotCommanderInterface):
         max_vel: float = 0.3,
         max_accel: float = 0.3,
     ) -> None:
-        pass
+        raise NotImplementedError
 
     def control_tcp_position_servo(
         self,

--- a/aegis_gym/sim/genesis/robot_commander_genesis.py
+++ b/aegis_gym/sim/genesis/robot_commander_genesis.py
@@ -72,9 +72,9 @@ class RobotCommanderSimGenesis(RobotCommanderInterface):
             link=self.robot.get_link("robotiq_hande_end"),
             pos=pos_np,
             quat=ori_np,
-        )
+        )[self.motor_dofs[0]:self.motor_dofs[-1]+1]
 
-        self.robot.control_dofs_position(qpos[self.motor_dofs], self.motor_dofs)
+        self.robot.control_dofs_position(qpos, self.motor_dofs)
 
     def move_to_home(self) -> None:
         # TODO(issue#8) Do we need trajectory to home in simulation?

--- a/aegis_gym/sim/genesis/robot_commander_genesis.py
+++ b/aegis_gym/sim/genesis/robot_commander_genesis.py
@@ -31,8 +31,8 @@ class RobotCommanderSimGenesis(RobotCommanderInterface):
         return th.cat([pos, ori])
 
     # TODO(issue#9): Limit velocity and acceleration for Genesis robot commander
-    # TODO(issue#23): Implement synchronous control for Genesis robot commander
 
+    # TODO(issue#23): Implement synchronous control for Genesis robot commander
     def control_dofs_position(
         self, target_pos: th.Tensor, max_vel: float = 0.3, max_accel: float = 0.3
     ) -> None:
@@ -43,6 +43,7 @@ class RobotCommanderSimGenesis(RobotCommanderInterface):
     ) -> None:
         self.robot.control_dofs_position(target_pos, self.motor_dofs)
 
+    # TODO(issue#23): Implement synchronous control for Genesis robot commander
     def control_tcp_position(
         self,
         target_pos: th.Tensor,
@@ -52,6 +53,7 @@ class RobotCommanderSimGenesis(RobotCommanderInterface):
     ) -> None:
         raise NotImplementedError
 
+    # TODO(issue#25): Investigate TCP frame reference discrepancy
     def control_tcp_position_servo(
         self,
         target_pos: th.Tensor,
@@ -73,7 +75,7 @@ class RobotCommanderSimGenesis(RobotCommanderInterface):
             link=self.robot.get_link(self.tcp_link_name),
             pos=pos_np,
             quat=ori_np,
-        )[self.motor_dofs[0]:self.motor_dofs[-1]+1]
+        )[self.motor_dofs[0] : self.motor_dofs[-1] + 1]
 
         self.robot.control_dofs_position(qpos, self.motor_dofs)
 

--- a/aegis_gym/sim/genesis/robot_commander_genesis.py
+++ b/aegis_gym/sim/genesis/robot_commander_genesis.py
@@ -11,6 +11,7 @@ class RobotCommanderSimGenesis(RobotCommanderInterface):
         super().__init__(device)
         self.robot = gs_robot
         self.motor_dofs = motor_dofs
+        self.tcp_link_name = "robotiq_hande_end"
 
     def get_joint_positions(self) -> th.Tensor:
         return self.robot.get_dofs_position(self.motor_dofs).clone().detach()
@@ -19,10 +20,10 @@ class RobotCommanderSimGenesis(RobotCommanderInterface):
         return self.robot.get_dofs_velocity(self.motor_dofs).clone().detach()
 
     def get_tcp_position(self) -> th.Tensor:
-        return self.robot.get_links_pos()[7, :].clone().detach()
+        return self.robot.get_link(self.tcp_link_name).get_pos().clone().detach()
 
     def get_tcp_orientation(self) -> th.Tensor:
-        return self.robot.get_links_quat()[7, :].clone().detach()
+        return self.robot.get_link(self.tcp_link_name).get_quat().clone().detach()
 
     def get_tcp_pose(self) -> th.Tensor:
         pos = self.get_tcp_position()
@@ -69,7 +70,7 @@ class RobotCommanderSimGenesis(RobotCommanderInterface):
         ori_np = target_ori.detach().cpu().numpy()
 
         qpos = self.robot.inverse_kinematics(
-            link=self.robot.get_link("robotiq_hande_end"),
+            link=self.robot.get_link(self.tcp_link_name),
             pos=pos_np,
             quat=ori_np,
         )[self.motor_dofs[0]:self.motor_dofs[-1]+1]

--- a/aegis_gym/sim/genesis/robot_commander_genesis.py
+++ b/aegis_gym/sim/genesis/robot_commander_genesis.py
@@ -29,10 +29,16 @@ class RobotCommanderSimGenesis(RobotCommanderInterface):
         ori = self.get_tcp_orientation()
         return th.cat([pos, ori])
 
+    # TODO(issue#9) use max cel and accel
+
     def control_dofs_position(
         self, target_pos: th.Tensor, max_vel: float = 0.3, max_accel: float = 0.3
     ) -> None:
-        # TODO(issue#9) use max cel and accel
+        pass
+
+    def control_dofs_position_servo(
+        self, target_pos: th.Tensor, max_vel: float = 0.3, max_accel: float = 0.3
+    ) -> None:
         self.robot.control_dofs_position(target_pos, self.motor_dofs)
 
     def control_tcp_position(
@@ -42,7 +48,25 @@ class RobotCommanderSimGenesis(RobotCommanderInterface):
         max_vel: float = 0.3,
         max_accel: float = 0.3,
     ) -> None:
-        raise NotImplementedError
+        pass
+
+    def control_tcp_position_servo(
+        self,
+        target_pos: th.Tensor,
+        target_ori: th.Tensor,
+        max_vel: float = 0.3,
+        max_accel: float = 0.3,
+    ) -> None:
+        pos_np = target_pos.detach().cpu().numpy()
+        ori_np = target_ori.detach().cpu().numpy()
+
+        qpos = self.robot.inverse_kinematics(
+            link=self.robot.get_link("robotiq_hande_end"),
+            pos=pos_np,
+            quat=ori_np,
+        )
+
+        self.robot.control_dofs_position(qpos[self.motor_dofs], self.motor_dofs)
 
     def move_to_home(self) -> None:
         # TODO(issue#8) Do we need trajectory to home in simulation?

--- a/aegis_gym/sim/genesis/robot_commander_genesis.py
+++ b/aegis_gym/sim/genesis/robot_commander_genesis.py
@@ -54,10 +54,17 @@ class RobotCommanderSimGenesis(RobotCommanderInterface):
     def control_tcp_position_servo(
         self,
         target_pos: th.Tensor,
-        target_ori: th.Tensor,
+        target_ori: th.Tensor | None = None,
         max_vel: float = 0.3,
         max_accel: float = 0.3,
     ) -> None:
+        if target_ori is None:
+            target_ori = th.tensor(
+                [0.0, 0.7071, 0.7071, 0.0],
+                dtype=th.float32,
+                device=self.device,
+            )
+
         pos_np = target_pos.detach().cpu().numpy()
         ori_np = target_ori.detach().cpu().numpy()
 

--- a/aegis_gym/sim/genesis/scene_director_genesis.py
+++ b/aegis_gym/sim/genesis/scene_director_genesis.py
@@ -26,8 +26,8 @@ SIM_CFG = {
         # 'robotiq_hande_right_finger_joint',
     ],
     # TODO(issue#16): Research tuning of PD gains for UR5e
-    "kp": [600, 600, 400, 400, 200, 200],
-    "kd": [60, 60, 40, 40, 20, 20],
+    "kp": [1000, 1000, 1000, 500, 500, 500],
+    "kd": [200, 200, 200, 100, 100, 100],
 }
 
 

--- a/aegis_gym/sim/genesis/scene_director_genesis.py
+++ b/aegis_gym/sim/genesis/scene_director_genesis.py
@@ -80,6 +80,7 @@ class SceneDirectorSimGenesis(SceneDirectorInterface):
                 file=generate_aegis_urdf(),
                 fixed=True,
                 pos=self.cfg["robot_pos"],
+                links_to_keep=["robotiq_hande_end"],
             ),
             material=gs.materials.Rigid(friction=0.6, coup_friction=0.6),
         )

--- a/aegis_gym/sim/genesis/scene_director_genesis.py
+++ b/aegis_gym/sim/genesis/scene_director_genesis.py
@@ -106,12 +106,10 @@ class SceneDirectorSimGenesis(SceneDirectorInterface):
     def build(self) -> None:
         self.scene.build()
 
-        self.motor_dofs = tuple(
-            [
-                self.robot.get_joint(name).dofs_idx_local[0]
-                for name in self.cfg["dof_names"]
-            ]
-        )
+        self.motor_dofs = []
+        for name in self.cfg["dof_names"]:
+            self.motor_dofs.append(self.robot.get_joint(name).dofs_idx_local[0])
+
         self.robot.set_dofs_kp(self.cfg["kp"], self.motor_dofs)
         self.robot.set_dofs_kv(self.cfg["kd"], self.motor_dofs)
 

--- a/aegis_gym/sim/genesis/scene_director_genesis.py
+++ b/aegis_gym/sim/genesis/scene_director_genesis.py
@@ -11,6 +11,7 @@ from ...sim import generate_aegis_urdf
 from .robot_commander_genesis import RobotCommanderSimGenesis
 from .scene_entities_genesis import EntityTypeSimGenesis
 
+# TODO(issue#24): Include robot fingers in DOF configuration in Genesis
 SIM_CFG = {
     "dt": 0.05,
     "robot_pos": [0.0, 0.0, 0.0],
@@ -112,7 +113,7 @@ class SceneDirectorSimGenesis(SceneDirectorInterface):
                 self.robot.get_joint(name).dofs_idx_local[0]
                 for name in self.cfg["dof_names"]
             ]
-        )     
+        )
 
         self.robot.set_dofs_kp(self.cfg["kp"], self.motor_dofs)
         self.robot.set_dofs_kv(self.cfg["kd"], self.motor_dofs)

--- a/aegis_gym/sim/genesis/scene_director_genesis.py
+++ b/aegis_gym/sim/genesis/scene_director_genesis.py
@@ -44,7 +44,7 @@ class SceneDirectorSimGenesis(SceneDirectorInterface):
     ):
         super().__init__(device, show_render)
         self.cfg = cfg
-        self.motor_dofs: tuple[str] = None
+        self.motor_dofs: tuple[int] = None
 
         if not gs._initialized:
             backend = gs.gpu if device in ("cuda", "gpu") else gs.cpu
@@ -107,9 +107,12 @@ class SceneDirectorSimGenesis(SceneDirectorInterface):
     def build(self) -> None:
         self.scene.build()
 
-        self.motor_dofs = []
-        for name in self.cfg["dof_names"]:
-            self.motor_dofs.append(self.robot.get_joint(name).dofs_idx_local[0])
+        self.motor_dofs = tuple(
+            [
+                self.robot.get_joint(name).dofs_idx_local[0]
+                for name in self.cfg["dof_names"]
+            ]
+        )     
 
         self.robot.set_dofs_kp(self.cfg["kp"], self.motor_dofs)
         self.robot.set_dofs_kv(self.cfg["kd"], self.motor_dofs)

--- a/test/sb3_run_train.py
+++ b/test/sb3_run_train.py
@@ -2,7 +2,7 @@ import time
 
 import gymnasium as gym
 
-import aegis_gym
+import aegis_gym  # noqa: F401
 import aegis_gym.sim.genesis as sim_genesis  # noqa: F401
 from aegis_gym.sim.utils import TorchToNumpyWrapper
 
@@ -16,7 +16,15 @@ except ImportError:
 
 
 def main():
+    # 0 JOINTS: move joints to target, waits until reached
+    # 1 JOINTS_SERVO: continuous joint commands
+    # 2 CARTESIAN_POSITION: move TCP to target, waits until reached
+    # 3 CARTESIAN_POSITION_SERVO: continuous TCP commands
+
+    # ROS
     env_name = aegis_gym.ENV_IDS[0]
+
+    # GENESIS
     # env_name = sim_genesis.ENV_IDS[0]
 
     print(f"Training on environment: {env_name}")

--- a/test/sb3_run_train.py
+++ b/test/sb3_run_train.py
@@ -16,16 +16,18 @@ except ImportError:
 
 
 def main():
-    # 0 JOINTS: move joints to target, waits until reached
-    # 1 JOINTS_SERVO: continuous joint commands
-    # 2 CARTESIAN_POSITION: move TCP to target, waits until reached
-    # 3 CARTESIAN_POSITION_SERVO: continuous TCP commands
+    CONTROL_TYPES = {
+        "JOINTS": 0,  # Move joints to target, waits until reached
+        "JOINTS_SERVO": 1,  # Continuous joint commands
+        "CARTESIAN_POSITION": 2,  # Move TCP to target, waits until reached
+        "CARTESIAN_POSITION_SERVO": 3,  # Continuous TCP commands
+    }
 
     # ROS
-    env_name = aegis_gym.ENV_IDS[0]
+    env_name = aegis_gym.ENV_IDS[CONTROL_TYPES["JOINTS"]]
 
     # GENESIS
-    # env_name = sim_genesis.ENV_IDS[0]
+    # env_name = sim_genesis.ENV_IDS[CONTROL_TYPES["JOINTS_SERVO"]]
 
     print(f"Training on environment: {env_name}")
 


### PR DESCRIPTION
## Description
This PR implements a Cartesian control method for the Genesis robot commander.

In addition: 
* it updates the naming convention for continuous control modes, 
* adjusts PD gains for improved stability, 
* introduces a TCP link in the Genesis setup for accurate Cartesian reference.


## Motivation and context
With this change, Cartesian control can now be tested directly in simulation.
The updated naming and control structure improve code clarity and maintain consistency across control modes.


## How has this been tested?
In Genesis and RViz.


## Checklist
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [ :cactus: ] All automated checks have passed.