### PR TITLE
Implement visual observations for Genesis

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
         args: [-w, --ignore-words=.codespell-ignore-words]
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.2
+    rev: v0.14.3
     hooks:
     -   id: ruff-check
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
         args: [-w, --ignore-words=.codespell-ignore-words]
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.0
+    rev: v0.14.2
     hooks:
     -   id: ruff-check
         args:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [PR-26](https://github.com/AGH-CEAI/pull/26) - Added support for multimodal observations in environments.
+- [PR-26](https://github.com/AGH-CEAI/pull/26) - Added a scene camera to Genesis simulation for visual observations.
 - [PR-21](https://github.com/AGH-CEAI/pull/21) - Added Cartesian control for Genesis robot commander.
 - [PR-19](https://github.com/AGH-CEAI/pull/19) - Added Cartesian control for ROS robot commander.
 - [PR-17](https://github.com/AGH-CEAI/pull/17) - Added Cartesian control for Reacher environment.
@@ -31,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [PR-26](https://github.com/AGH-CEAI/pull/26) - Fixed pose retrieval for Genesis entities.
 - [PR-21](https://github.com/AGH-CEAI/aegis_gym/pull/21) - Fixed TCP link handling in Genesis.
 
 ### Security

--- a/aegis_gym/envs/aegis_pusher.py
+++ b/aegis_gym/envs/aegis_pusher.py
@@ -21,7 +21,6 @@ from .env_types import EnvControlType, EnvObservationType, EnvRewardType, EnvRen
 
 ENV_CFG = {
     "max_episode_length": 1000,
-    "num_obs": 21,
     "target_pos": [-0.1, 0.76, 0.84],
     "target_threshold": 0.04,
     "object_spawn_x": [-0.36, -0.24],
@@ -76,7 +75,6 @@ class AegisPusherEnv(gym.Env):
 
         # TODO(issue#7) Rconsider episode length units unifcation for ROS and simulation
         self.max_episode_length = cfg["max_episode_length"]
-        self.num_obs = cfg["num_obs"]
         self.target_threshold = cfg["target_threshold"]
         self.clip_action = cfg["clip_action"]
         self.obs_scales = cfg["obs_scales"]
@@ -96,11 +94,18 @@ class AegisPusherEnv(gym.Env):
         match self.observation_type:
             case EnvObservationType.STATE:
                 self.observation_space: spaces.Space[th.Tensor] = spaces.Box(
-                    low=-np.inf, high=np.inf, shape=(self.num_obs,), dtype=np.float32
+                    low=-np.inf, high=np.inf, shape=(21,), dtype=np.float32
                 )
             case EnvObservationType.VISION:
-                self.observation_space = spaces.Box(
-                    low=0, high=255, shape=(128, 128, 3), dtype=np.uint8
+                self.observation_space = spaces.Dict(
+                    {
+                        "state": spaces.Box(
+                            low=-np.inf, high=np.inf, shape=(18,), dtype=np.float32
+                        ),
+                        "vision": spaces.Box(
+                            low=0, high=255, shape=(128, 128, 3), dtype=np.uint8
+                        ),
+                    }
                 )
             case _:
                 raise ValueError(
@@ -224,7 +229,7 @@ class AegisPusherEnv(gym.Env):
                 self.dof_pos = self.robot.get_joint_positions()
                 self.dof_vel = self.robot.get_joint_velocities()
                 self.tcp_pos = self.robot.get_tcp_position()
-                self.object_pos = self.object.get_pose()[:3].clone()
+                self.object_pos = self.object.get_pose()[:3]
                 return (
                     th.cat(
                         [
@@ -239,6 +244,12 @@ class AegisPusherEnv(gym.Env):
                     .detach()
                 )
             case EnvObservationType.VISION:
+                self.dof_pos = self.robot.get_joint_positions()
+                self.dof_vel = self.robot.get_joint_velocities()
+                self.tcp_pos = self.robot.get_tcp_position()
+                self.object_pos = self.object.get_pose()[:3]
+                state_obs = th.cat([self.dof_pos, self.dof_vel, self.tcp_pos]).clone().detach()
+
                 rgb, depth, seg, normal = self.scene.camera.render(
                     depth=False, segmentation=False, normal=False
                 )
@@ -247,8 +258,9 @@ class AegisPusherEnv(gym.Env):
                     (128, 128),
                     interpolation=cv2.INTER_AREA,
                 )
-                obs = th.tensor(rgb_proc, dtype=th.float32, device=self.device) / 255.0
-                return obs
+                vision_obs = th.tensor(rgb_proc, dtype=th.float32, device=self.device) / 255.0
+
+                return {"state": state_obs, "vision": vision_obs}
             case _:
                 raise ValueError(
                     f"Unsupported observation type: {self.observation_type}"

--- a/aegis_gym/envs/aegis_pusher.py
+++ b/aegis_gym/envs/aegis_pusher.py
@@ -62,17 +62,6 @@ class AegisPusherEnv(gym.Env):
         self.control_type = EnvControlType(control_type)
         self.reward_type = EnvRewardType(reward_type)
 
-        match self.control_type:
-            case EnvControlType.JOINTS | EnvControlType.JOINTS_SERVO:
-                self.num_actions = 6
-            case (
-                EnvControlType.CARTESIAN_POSITION
-                | EnvControlType.CARTESIAN_POSITION_SERVO
-            ):
-                self.num_actions = 3
-            case _:
-                raise ValueError(f"Unsupported control type: {self.control_type}")
-
         # TODO(issue#7) Rconsider episode length units unifcation for ROS and simulation
         self.max_episode_length = cfg["max_episode_length"]
         self.target_threshold = cfg["target_threshold"]
@@ -82,7 +71,9 @@ class AegisPusherEnv(gym.Env):
         self.reward_scales = cfg["reward_scales"]
 
         enable_scene_camera = self.observation_type == EnvObservationType.MULTIMODAL
-        self.scene: SceneDirectorInterface = get_scene_director(scene_type, enable_scene_camera)
+        self.scene: SceneDirectorInterface = get_scene_director(
+            scene_type, enable_scene_camera
+        )
         self.target: Target = self.scene.add_entity(EntityType.TARGET)
         self.object: Box = self.scene.add_entity(EntityType.BOX)
         self.target.create()
@@ -91,33 +82,11 @@ class AegisPusherEnv(gym.Env):
         self.scene.build()
         self.robot: RobotCommanderInterface = self.scene.get_robot_commander()
 
-        match self.observation_type:
-            case EnvObservationType.STATE:
-                self.observation_space: spaces.Space[th.Tensor] = spaces.Box(
-                    low=-np.inf, high=np.inf, shape=(21,), dtype=np.float32
-                )
-            case EnvObservationType.MULTIMODAL:
-                self.observation_space = spaces.Dict(
-                    {
-                        "state": spaces.Box(
-                            low=-np.inf, high=np.inf, shape=(18,), dtype=np.float32
-                        ),
-                        "vision": spaces.Box(
-                            low=0, high=255, shape=(128, 128, 3), dtype=np.uint8
-                        ),
-                    }
-                )
-            case _:
-                raise ValueError(
-                    f"Unsupported observation type: {self.observation_type}"
-                )
-
-        self.action_space: spaces.Space[th.Tensor] = spaces.Box(
-            low=-1.0, high=1.0, shape=(self.num_actions,), dtype=np.float32
-        )
+        self.observation_space = self._make_observation_space()
+        self.action_space = self._make_action_space()
 
         self.episode_step = 0.0
-        self.actions = th.zeros(self.num_actions, device=self.device)
+        self.actions = th.zeros(self.action_space.shape, device=self.device)
         self.dof_pos = th.zeros(6, device=self.device)
         self.dof_vel = th.zeros(6, device=self.device)
         self.tcp_pos = th.zeros(3, device=self.device)
@@ -133,6 +102,40 @@ class AegisPusherEnv(gym.Env):
         }
         self.episode_sums = {key: 0.0 for key in self.reward_functions}
         self.reset()
+
+    def _make_observation_space(self) -> spaces.Space[th.Tensor]:
+        match self.observation_type:
+            case EnvObservationType.STATE:
+                return spaces.Box(
+                    low=-np.inf, high=np.inf, shape=(21,), dtype=np.float32
+                )
+            case EnvObservationType.MULTIMODAL:
+                return spaces.Dict(
+                    {
+                        "state": spaces.Box(
+                            low=-np.inf, high=np.inf, shape=(18,), dtype=np.float32
+                        ),
+                        "vision": spaces.Box(
+                            low=0, high=255, shape=(128, 128, 3), dtype=np.uint8
+                        ),
+                    }
+                )
+            case _:
+                raise ValueError(
+                    f"Unsupported observation type: {self.observation_type}"
+                )
+
+    def _make_action_space(self) -> spaces.Space[th.Tensor]:
+        match self.control_type:
+            case EnvControlType.JOINTS | EnvControlType.JOINTS_SERVO:
+                return spaces.Box(low=-1.0, high=1.0, shape=(6,), dtype=np.float32)
+            case (
+                EnvControlType.CARTESIAN_POSITION
+                | EnvControlType.CARTESIAN_POSITION_SERVO
+            ):
+                return spaces.Box(low=-1.0, high=1.0, shape=(3,), dtype=np.float32)
+            case _:
+                raise ValueError(f"Unsupported control type: {self.control_type}")
 
     def step(
         self, action: Union[th.Tensor, np.ndarray]

--- a/aegis_gym/envs/aegis_pusher.py
+++ b/aegis_gym/envs/aegis_pusher.py
@@ -81,8 +81,8 @@ class AegisPusherEnv(gym.Env):
         self.action_scale = cfg["action_scale"]
         self.reward_scales = cfg["reward_scales"]
 
-        visual_obs = self.observation_type == EnvObservationType.VISION
-        self.scene: SceneDirectorInterface = get_scene_director(scene_type, visual_obs)
+        enable_scene_camera = self.observation_type == EnvObservationType.MULTIMODAL
+        self.scene: SceneDirectorInterface = get_scene_director(scene_type, enable_scene_camera)
         self.target: Target = self.scene.add_entity(EntityType.TARGET)
         self.object: Box = self.scene.add_entity(EntityType.BOX)
         self.target.create()
@@ -96,7 +96,7 @@ class AegisPusherEnv(gym.Env):
                 self.observation_space: spaces.Space[th.Tensor] = spaces.Box(
                     low=-np.inf, high=np.inf, shape=(21,), dtype=np.float32
                 )
-            case EnvObservationType.VISION:
+            case EnvObservationType.MULTIMODAL:
                 self.observation_space = spaces.Dict(
                     {
                         "state": spaces.Box(
@@ -243,7 +243,7 @@ class AegisPusherEnv(gym.Env):
                     .clone()
                     .detach()
                 )
-            case EnvObservationType.VISION:
+            case EnvObservationType.MULTIMODAL:
                 self.dof_pos = self.robot.get_joint_positions()
                 self.dof_vel = self.robot.get_joint_velocities()
                 self.tcp_pos = self.robot.get_tcp_position()

--- a/aegis_gym/envs/aegis_pusher.py
+++ b/aegis_gym/envs/aegis_pusher.py
@@ -2,9 +2,10 @@
 # Major refactor by Maciej Aleksandrowicz (macmacal) 2025
 from typing import Any, Optional, Union
 
-import gymnasium as gym
+import cv2
 import numpy as np
 import torch as th
+import gymnasium as gym
 from gymnasium import spaces
 
 from ..scene import (
@@ -82,7 +83,8 @@ class AegisPusherEnv(gym.Env):
         self.action_scale = cfg["action_scale"]
         self.reward_scales = cfg["reward_scales"]
 
-        self.scene: SceneDirectorInterface = get_scene_director(scene_type)
+        visual_obs = self.observation_type == EnvObservationType.VISION
+        self.scene: SceneDirectorInterface = get_scene_director(scene_type, visual_obs)
         self.target: Target = self.scene.add_entity(EntityType.TARGET)
         self.object: Box = self.scene.add_entity(EntityType.BOX)
         self.target.create()
@@ -91,9 +93,20 @@ class AegisPusherEnv(gym.Env):
         self.scene.build()
         self.robot: RobotCommanderInterface = self.scene.get_robot_commander()
 
-        self.observation_space: spaces.Space[th.Tensor] = spaces.Box(
-            low=-np.inf, high=np.inf, shape=(self.num_obs,), dtype=np.float32
-        )
+        match self.observation_type:
+            case EnvObservationType.STATE:
+                self.observation_space: spaces.Space[th.Tensor] = spaces.Box(
+                    low=-np.inf, high=np.inf, shape=(self.num_obs,), dtype=np.float32
+                )
+            case EnvObservationType.VISION:
+                self.observation_space = spaces.Box(
+                    low=0, high=255, shape=(128, 128, 3), dtype=np.uint8
+                )
+            case _:
+                raise ValueError(
+                    f"Unsupported observation type: {self.observation_type}"
+                )
+
         self.action_space: spaces.Space[th.Tensor] = spaces.Box(
             low=-1.0, high=1.0, shape=(self.num_actions,), dtype=np.float32
         )
@@ -206,23 +219,40 @@ class AegisPusherEnv(gym.Env):
         return obs, {}
 
     def _get_obs(self) -> th.Tensor:
-        self.dof_pos = self.robot.get_joint_positions()
-        self.dof_vel = self.robot.get_joint_velocities()
-        self.tcp_pos = self.robot.get_tcp_position()
-        self.object_pos = self.object.get_pose()[:3].clone()
-        return (
-            th.cat(
-                [
-                    self.dof_pos,
-                    self.dof_vel,
-                    self.tcp_pos,
-                    self.object_pos,
-                    self.target_pos,
-                ]
-            )
-            .clone()
-            .detach()
-        )
+        match self.observation_type:
+            case EnvObservationType.STATE:
+                self.dof_pos = self.robot.get_joint_positions()
+                self.dof_vel = self.robot.get_joint_velocities()
+                self.tcp_pos = self.robot.get_tcp_position()
+                self.object_pos = self.object.get_pose()[:3].clone()
+                return (
+                    th.cat(
+                        [
+                            self.dof_pos,
+                            self.dof_vel,
+                            self.tcp_pos,
+                            self.object_pos,
+                            self.target_pos,
+                        ]
+                    )
+                    .clone()
+                    .detach()
+                )
+            case EnvObservationType.VISION:
+                rgb, depth, seg, normal = self.scene.camera.render(
+                    depth=False, segmentation=False, normal=False
+                )
+                rgb_proc = cv2.resize(
+                    np.ascontiguousarray(np.flipud(rgb)),
+                    (128, 128),
+                    interpolation=cv2.INTER_AREA,
+                )
+                obs = th.tensor(rgb_proc, dtype=th.float32, device=self.device) / 255.0
+                return obs
+            case _:
+                raise ValueError(
+                    f"Unsupported observation type: {self.observation_type}"
+                )
 
     def _get_info(
         self,

--- a/aegis_gym/envs/aegis_pusher.py
+++ b/aegis_gym/envs/aegis_pusher.py
@@ -248,7 +248,9 @@ class AegisPusherEnv(gym.Env):
                 self.dof_vel = self.robot.get_joint_velocities()
                 self.tcp_pos = self.robot.get_tcp_position()
                 self.object_pos = self.object.get_pose()[:3]
-                state_obs = th.cat([self.dof_pos, self.dof_vel, self.tcp_pos]).clone().detach()
+                state_obs = (
+                    th.cat([self.dof_pos, self.dof_vel, self.tcp_pos]).clone().detach()
+                )
 
                 rgb, depth, seg, normal = self.scene.camera.render(
                     depth=False, segmentation=False, normal=False
@@ -258,7 +260,9 @@ class AegisPusherEnv(gym.Env):
                     (128, 128),
                     interpolation=cv2.INTER_AREA,
                 )
-                vision_obs = th.tensor(rgb_proc, dtype=th.float32, device=self.device) / 255.0
+                vision_obs = (
+                    th.tensor(rgb_proc, dtype=th.float32, device=self.device) / 255.0
+                )
 
                 return {"state": state_obs, "vision": vision_obs}
             case _:

--- a/aegis_gym/envs/aegis_pusher.py
+++ b/aegis_gym/envs/aegis_pusher.py
@@ -227,12 +227,13 @@ class AegisPusherEnv(gym.Env):
         return obs, {}
 
     def _get_obs(self) -> th.Tensor:
+        self.dof_pos = self.robot.get_joint_positions()
+        self.dof_vel = self.robot.get_joint_velocities()
+        self.tcp_pos = self.robot.get_tcp_position()
+        self.object_pos = self.object.get_pose()[:3]
+
         match self.observation_type:
             case EnvObservationType.STATE:
-                self.dof_pos = self.robot.get_joint_positions()
-                self.dof_vel = self.robot.get_joint_velocities()
-                self.tcp_pos = self.robot.get_tcp_position()
-                self.object_pos = self.object.get_pose()[:3]
                 return (
                     th.cat(
                         [
@@ -247,10 +248,6 @@ class AegisPusherEnv(gym.Env):
                     .detach()
                 )
             case EnvObservationType.MULTIMODAL:
-                self.dof_pos = self.robot.get_joint_positions()
-                self.dof_vel = self.robot.get_joint_velocities()
-                self.tcp_pos = self.robot.get_tcp_position()
-                self.object_pos = self.object.get_pose()[:3]
                 state_obs = (
                     th.cat([self.dof_pos, self.dof_vel, self.tcp_pos]).clone().detach()
                 )
@@ -258,20 +255,21 @@ class AegisPusherEnv(gym.Env):
                 rgb, depth, seg, normal = self.scene.camera.render(
                     depth=False, segmentation=False, normal=False
                 )
-                rgb_proc = cv2.resize(
-                    np.ascontiguousarray(np.flipud(rgb)),
-                    (128, 128),
-                    interpolation=cv2.INTER_AREA,
-                )
-                vision_obs = (
-                    th.tensor(rgb_proc, dtype=th.float32, device=self.device) / 255.0
-                )
+                vision_obs = self._process_rgb(rgb)
 
                 return {"state": state_obs, "vision": vision_obs}
             case _:
                 raise ValueError(
                     f"Unsupported observation type: {self.observation_type}"
                 )
+
+    def _process_rgb(self, rgb: np.ndarray) -> th.Tensor:
+        rgb_proc = cv2.resize(
+            np.ascontiguousarray(np.flipud(rgb)),
+            (128, 128),
+            interpolation=cv2.INTER_AREA,
+        )
+        return th.tensor(rgb_proc, dtype=th.float32, device=self.device) / 255.0
 
     def _get_info(
         self,

--- a/aegis_gym/envs/aegis_reacher.py
+++ b/aegis_gym/envs/aegis_reacher.py
@@ -21,7 +21,6 @@ from .env_types import EnvControlType, EnvObservationType, EnvRewardType, EnvRen
 
 ENV_CFG = {
     "max_episode_length": 1000,
-    "num_obs": 18,
     "target_threshold": 0.02,
     "target_spawn_x": [-0.26, 0.26],
     "target_spawn_y": [0.36, 1.0],
@@ -68,7 +67,6 @@ class AegisReacherEnv(gym.Env):
 
         # TODO(issue#7) Rconsider episode length units unifcation for ROS and simulation
         self.max_episode_length = cfg["max_episode_length"]
-        self.num_obs = cfg["num_obs"]
         self.target_threshold = cfg["target_threshold"]
         self.clip_action = cfg["clip_action"]
         self.obs_scales = cfg["obs_scales"]
@@ -89,11 +87,18 @@ class AegisReacherEnv(gym.Env):
         match self.observation_type:
             case EnvObservationType.STATE:
                 self.observation_space: spaces.Space[th.Tensor] = spaces.Box(
-                    low=-np.inf, high=np.inf, shape=(self.num_obs,), dtype=np.float32
+                    low=-np.inf, high=np.inf, shape=(18,), dtype=np.float32
                 )
             case EnvObservationType.VISION:
-                self.observation_space = spaces.Box(
-                    low=0, high=255, shape=(128, 128, 3), dtype=np.uint8
+                self.observation_space = spaces.Dict(
+                    {
+                        "state": spaces.Box(
+                            low=-np.inf, high=np.inf, shape=(15,), dtype=np.float32
+                        ),
+                        "vision": spaces.Box(
+                            low=0, high=255, shape=(128, 128, 3), dtype=np.uint8
+                        ),
+                    }
                 )
             case _:
                 raise ValueError(
@@ -194,6 +199,7 @@ class AegisReacherEnv(gym.Env):
                 dtype=th.float32,
             )
         )
+        self.target_pos = self.target.get_pose()[:3]
 
         obs = self._get_obs()
         self.dist_to_target = th.norm(self.tcp_pos - self.target_pos)
@@ -218,6 +224,11 @@ class AegisReacherEnv(gym.Env):
                     .detach()
                 )
             case EnvObservationType.VISION:
+                self.dof_pos = self.robot.get_joint_positions()
+                self.dof_vel = self.robot.get_joint_velocities()
+                self.tcp_pos = self.robot.get_tcp_position()
+                state_obs = th.cat([self.dof_pos, self.dof_vel, self.tcp_pos]).clone().detach()
+
                 rgb, depth, seg, normal = self.scene.camera.render(
                     depth=False, segmentation=False, normal=False
                 )
@@ -226,8 +237,9 @@ class AegisReacherEnv(gym.Env):
                     (128, 128),
                     interpolation=cv2.INTER_AREA,
                 )
-                obs = th.tensor(rgb_proc, dtype=th.float32, device=self.device) / 255.0
-                return obs
+                vision_obs = th.tensor(rgb_proc, dtype=th.float32, device=self.device) / 255.0
+
+                return {"state": state_obs, "vision": vision_obs}
             case _:
                 raise ValueError(
                     f"Unsupported observation type: {self.observation_type}"

--- a/aegis_gym/envs/aegis_reacher.py
+++ b/aegis_gym/envs/aegis_reacher.py
@@ -3,6 +3,7 @@
 import time
 from typing import Optional, Any, Union
 
+import cv2
 import numpy as np
 import torch as th
 import gymnasium as gym
@@ -77,16 +78,28 @@ class AegisReacherEnv(gym.Env):
         self.target_spawn_y = cfg["target_spawn_y"]
         self.target_spawn_z = cfg["target_spawn_z"]
 
-        self.scene: SceneDirectorInterface = get_scene_director(scene_type)
+        visual_obs = self.observation_type == EnvObservationType.VISION
+        self.scene: SceneDirectorInterface = get_scene_director(scene_type, visual_obs)
         self.target: Target = self.scene.add_entity(EntityType.TARGET)
         self.target.create()
 
         self.scene.build()
         self.robot: RobotCommanderInterface = self.scene.get_robot_commander()
 
-        self.observation_space: spaces.Space[th.Tensor] = spaces.Box(
-            low=-np.inf, high=np.inf, shape=(self.num_obs,), dtype=np.float32
-        )
+        match self.observation_type:
+            case EnvObservationType.STATE:
+                self.observation_space: spaces.Space[th.Tensor] = spaces.Box(
+                    low=-np.inf, high=np.inf, shape=(self.num_obs,), dtype=np.float32
+                )
+            case EnvObservationType.VISION:
+                self.observation_space = spaces.Box(
+                    low=0, high=255, shape=(128, 128, 3), dtype=np.uint8
+                )
+            case _:
+                raise ValueError(
+                    f"Unsupported observation type: {self.observation_type}"
+                )
+
         self.action_space: spaces.Space[th.Tensor] = spaces.Box(
             low=-1.0, high=1.0, shape=(self.num_actions,), dtype=np.float32
         )
@@ -194,14 +207,31 @@ class AegisReacherEnv(gym.Env):
         return obs, {}
 
     def _get_obs(self) -> th.Tensor:
-        self.dof_pos = self.robot.get_joint_positions()
-        self.dof_vel = self.robot.get_joint_velocities()
-        self.tcp_pos = self.robot.get_tcp_position()
-        return (
-            th.cat([self.dof_pos, self.dof_vel, self.tcp_pos, self.target_pos])
-            .clone()
-            .detach()
-        )
+        match self.observation_type:
+            case EnvObservationType.STATE:
+                self.dof_pos = self.robot.get_joint_positions()
+                self.dof_vel = self.robot.get_joint_velocities()
+                self.tcp_pos = self.robot.get_tcp_position()
+                return (
+                    th.cat([self.dof_pos, self.dof_vel, self.tcp_pos, self.target_pos])
+                    .clone()
+                    .detach()
+                )
+            case EnvObservationType.VISION:
+                rgb, depth, seg, normal = self.scene.camera.render(
+                    depth=False, segmentation=False, normal=False
+                )
+                rgb_proc = cv2.resize(
+                    np.ascontiguousarray(np.flipud(rgb)),
+                    (128, 128),
+                    interpolation=cv2.INTER_AREA,
+                )
+                obs = th.tensor(rgb_proc, dtype=th.float32, device=self.device) / 255.0
+                return obs
+            case _:
+                raise ValueError(
+                    f"Unsupported observation type: {self.observation_type}"
+                )
 
     def _get_info(
         self,

--- a/aegis_gym/envs/aegis_reacher.py
+++ b/aegis_gym/envs/aegis_reacher.py
@@ -227,7 +227,9 @@ class AegisReacherEnv(gym.Env):
                 self.dof_pos = self.robot.get_joint_positions()
                 self.dof_vel = self.robot.get_joint_velocities()
                 self.tcp_pos = self.robot.get_tcp_position()
-                state_obs = th.cat([self.dof_pos, self.dof_vel, self.tcp_pos]).clone().detach()
+                state_obs = (
+                    th.cat([self.dof_pos, self.dof_vel, self.tcp_pos]).clone().detach()
+                )
 
                 rgb, depth, seg, normal = self.scene.camera.render(
                     depth=False, segmentation=False, normal=False
@@ -237,7 +239,9 @@ class AegisReacherEnv(gym.Env):
                     (128, 128),
                     interpolation=cv2.INTER_AREA,
                 )
-                vision_obs = th.tensor(rgb_proc, dtype=th.float32, device=self.device) / 255.0
+                vision_obs = (
+                    th.tensor(rgb_proc, dtype=th.float32, device=self.device) / 255.0
+                )
 
                 return {"state": state_obs, "vision": vision_obs}
             case _:

--- a/aegis_gym/envs/aegis_reacher.py
+++ b/aegis_gym/envs/aegis_reacher.py
@@ -76,8 +76,8 @@ class AegisReacherEnv(gym.Env):
         self.target_spawn_y = cfg["target_spawn_y"]
         self.target_spawn_z = cfg["target_spawn_z"]
 
-        visual_obs = self.observation_type == EnvObservationType.VISION
-        self.scene: SceneDirectorInterface = get_scene_director(scene_type, visual_obs)
+        enable_scene_camera = self.observation_type == EnvObservationType.MULTIMODAL
+        self.scene: SceneDirectorInterface = get_scene_director(scene_type, enable_scene_camera)
         self.target: Target = self.scene.add_entity(EntityType.TARGET)
         self.target.create()
 
@@ -89,7 +89,7 @@ class AegisReacherEnv(gym.Env):
                 self.observation_space: spaces.Space[th.Tensor] = spaces.Box(
                     low=-np.inf, high=np.inf, shape=(18,), dtype=np.float32
                 )
-            case EnvObservationType.VISION:
+            case EnvObservationType.MULTIMODAL:
                 self.observation_space = spaces.Dict(
                     {
                         "state": spaces.Box(
@@ -223,7 +223,7 @@ class AegisReacherEnv(gym.Env):
                     .clone()
                     .detach()
                 )
-            case EnvObservationType.VISION:
+            case EnvObservationType.MULTIMODAL:
                 self.dof_pos = self.robot.get_joint_positions()
                 self.dof_vel = self.robot.get_joint_velocities()
                 self.tcp_pos = self.robot.get_tcp_position()

--- a/aegis_gym/envs/aegis_reacher.py
+++ b/aegis_gym/envs/aegis_reacher.py
@@ -218,20 +218,18 @@ class AegisReacherEnv(gym.Env):
         return obs, {}
 
     def _get_obs(self) -> th.Tensor:
+        self.dof_pos = self.robot.get_joint_positions()
+        self.dof_vel = self.robot.get_joint_velocities()
+        self.tcp_pos = self.robot.get_tcp_position()
+
         match self.observation_type:
             case EnvObservationType.STATE:
-                self.dof_pos = self.robot.get_joint_positions()
-                self.dof_vel = self.robot.get_joint_velocities()
-                self.tcp_pos = self.robot.get_tcp_position()
                 return (
                     th.cat([self.dof_pos, self.dof_vel, self.tcp_pos, self.target_pos])
                     .clone()
                     .detach()
                 )
             case EnvObservationType.MULTIMODAL:
-                self.dof_pos = self.robot.get_joint_positions()
-                self.dof_vel = self.robot.get_joint_velocities()
-                self.tcp_pos = self.robot.get_tcp_position()
                 state_obs = (
                     th.cat([self.dof_pos, self.dof_vel, self.tcp_pos]).clone().detach()
                 )
@@ -239,20 +237,21 @@ class AegisReacherEnv(gym.Env):
                 rgb, depth, seg, normal = self.scene.camera.render(
                     depth=False, segmentation=False, normal=False
                 )
-                rgb_proc = cv2.resize(
-                    np.ascontiguousarray(np.flipud(rgb)),
-                    (128, 128),
-                    interpolation=cv2.INTER_AREA,
-                )
-                vision_obs = (
-                    th.tensor(rgb_proc, dtype=th.float32, device=self.device) / 255.0
-                )
+                vision_obs = self._process_rgb(rgb)
 
                 return {"state": state_obs, "vision": vision_obs}
             case _:
                 raise ValueError(
                     f"Unsupported observation type: {self.observation_type}"
                 )
+
+    def _process_rgb(self, rgb: np.ndarray) -> th.Tensor:
+        rgb_proc = cv2.resize(
+            np.ascontiguousarray(np.flipud(rgb)),
+            (128, 128),
+            interpolation=cv2.INTER_AREA,
+        )
+        return th.tensor(rgb_proc, dtype=th.float32, device=self.device) / 255.0
 
     def _get_info(
         self,

--- a/aegis_gym/envs/aegis_reacher.py
+++ b/aegis_gym/envs/aegis_reacher.py
@@ -54,17 +54,6 @@ class AegisReacherEnv(gym.Env):
         self.control_type = EnvControlType(control_type)
         self.reward_type = EnvRewardType(reward_type)
 
-        match self.control_type:
-            case EnvControlType.JOINTS | EnvControlType.JOINTS_SERVO:
-                self.num_actions = 6
-            case (
-                EnvControlType.CARTESIAN_POSITION
-                | EnvControlType.CARTESIAN_POSITION_SERVO
-            ):
-                self.num_actions = 3
-            case _:
-                raise ValueError(f"Unsupported control type: {self.control_type}")
-
         # TODO(issue#7) Rconsider episode length units unifcation for ROS and simulation
         self.max_episode_length = cfg["max_episode_length"]
         self.target_threshold = cfg["target_threshold"]
@@ -77,20 +66,42 @@ class AegisReacherEnv(gym.Env):
         self.target_spawn_z = cfg["target_spawn_z"]
 
         enable_scene_camera = self.observation_type == EnvObservationType.MULTIMODAL
-        self.scene: SceneDirectorInterface = get_scene_director(scene_type, enable_scene_camera)
+        self.scene: SceneDirectorInterface = get_scene_director(
+            scene_type, enable_scene_camera
+        )
         self.target: Target = self.scene.add_entity(EntityType.TARGET)
         self.target.create()
 
         self.scene.build()
         self.robot: RobotCommanderInterface = self.scene.get_robot_commander()
 
+        self.observation_space = self._make_observation_space()
+        self.action_space = self._make_action_space()
+
+        self.episode_step = 0.0
+        self.actions = th.zeros(
+            self.action_space.shape, dtype=th.float32, device=self.device
+        )
+        self.target_pos = th.zeros(3, dtype=th.float32, device=self.device)
+        self.dof_pos = th.zeros(6, dtype=th.float32, device=self.device)
+        self.dof_vel = th.zeros(6, dtype=th.float32, device=self.device)
+        self.tcp_pos = th.zeros(3, dtype=th.float32, device=self.device)
+
+        self.reward_functions = {
+            "dist": self._reward_dist,
+            "control": self._reward_control,
+        }
+        self.episode_sums = {key: 0.0 for key in self.reward_functions}
+        self.reset()
+
+    def _make_observation_space(self) -> spaces.Space[th.Tensor]:
         match self.observation_type:
             case EnvObservationType.STATE:
-                self.observation_space: spaces.Space[th.Tensor] = spaces.Box(
+                return spaces.Box(
                     low=-np.inf, high=np.inf, shape=(18,), dtype=np.float32
                 )
             case EnvObservationType.MULTIMODAL:
-                self.observation_space = spaces.Dict(
+                return spaces.Dict(
                     {
                         "state": spaces.Box(
                             low=-np.inf, high=np.inf, shape=(15,), dtype=np.float32
@@ -105,23 +116,17 @@ class AegisReacherEnv(gym.Env):
                     f"Unsupported observation type: {self.observation_type}"
                 )
 
-        self.action_space: spaces.Space[th.Tensor] = spaces.Box(
-            low=-1.0, high=1.0, shape=(self.num_actions,), dtype=np.float32
-        )
-
-        self.episode_step = 0.0
-        self.actions = th.zeros(self.num_actions, dtype=th.float32, device=self.device)
-        self.target_pos = th.zeros(3, dtype=th.float32, device=self.device)
-        self.dof_pos = th.zeros(6, dtype=th.float32, device=self.device)
-        self.dof_vel = th.zeros(6, dtype=th.float32, device=self.device)
-        self.tcp_pos = th.zeros(3, dtype=th.float32, device=self.device)
-
-        self.reward_functions = {
-            "dist": self._reward_dist,
-            "control": self._reward_control,
-        }
-        self.episode_sums = {key: 0.0 for key in self.reward_functions}
-        self.reset()
+    def _make_action_space(self) -> spaces.Space[th.Tensor]:
+        match self.control_type:
+            case EnvControlType.JOINTS | EnvControlType.JOINTS_SERVO:
+                return spaces.Box(low=-1.0, high=1.0, shape=(6,), dtype=np.float32)
+            case (
+                EnvControlType.CARTESIAN_POSITION
+                | EnvControlType.CARTESIAN_POSITION_SERVO
+            ):
+                return spaces.Box(low=-1.0, high=1.0, shape=(3,), dtype=np.float32)
+            case _:
+                raise ValueError(f"Unsupported control type: {self.control_type}")
 
     def step(
         self, action: Union[th.Tensor, np.ndarray]

--- a/aegis_gym/envs/env_types.py
+++ b/aegis_gym/envs/env_types.py
@@ -16,6 +16,7 @@ class EnvRewardType(LowercaseStrEnum):
 class EnvObservationType(LowercaseStrEnum):
     STATE = auto()
     VISION = auto()
+    MULTIMODAL = auto()
 
 
 class EnvControlType(LowercaseStrEnum):

--- a/aegis_gym/ros/scene_director_ros.py
+++ b/aegis_gym/ros/scene_director_ros.py
@@ -29,7 +29,7 @@ class SceneDirectorROS(SceneDirectorInterface):
     def __del__(self) -> None:
         self.shutdown()
 
-    def __init__(self, device: str = "cuda") -> None:
+    def __init__(self, device: str = "cuda", enable_scene_camera: bool = False) -> None:
         if hasattr(self, "_initialized") and self._initialized:
             return
         super().__init__(device)

--- a/aegis_gym/scene/scene_director_factory.py
+++ b/aegis_gym/scene/scene_director_factory.py
@@ -23,6 +23,7 @@ class SceneDirectorType(StrEnum):
 
 def get_scene_director(
     mode: SceneDirectorType = SceneDirectorType.ROS,
+    visual_obs: bool = False,
 ) -> SceneDirectorInterface:
     if is_mock_needed():
         print("\n> Deteceted pytest env, using MOCK env implementations.")
@@ -52,7 +53,7 @@ def get_scene_director(
                 SceneDirectorSimGenesis = None
 
             if SceneDirectorSimGenesis:
-                return SceneDirectorSimGenesis()
+                return SceneDirectorSimGenesis(visual_obs=visual_obs)
             warnings.warn(
                 "\n[IMPORT ERROR] Failed to import SceneDirectorSimGenesis. Double check if the 'aegis_gym' is instatalled with optional dependencies: 'pip3 install ./aegis_gym.whl[sim-genesis]'."
             )

--- a/aegis_gym/scene/scene_director_factory.py
+++ b/aegis_gym/scene/scene_director_factory.py
@@ -40,7 +40,7 @@ def get_scene_director(
                 SceneDirectorROS = None
 
             if SceneDirectorROS:
-                return SceneDirectorROS()
+                return SceneDirectorROS(enable_scene_camera=enable_scene_camera)
             warnings.warn(
                 "\n[IMPORT ERROR] Failed to import SceneDirectorROS. Double check if the ROS is sourced properly via `source /opt/ros/ROS_DISTRO/setup.sh`."
             )

--- a/aegis_gym/scene/scene_director_factory.py
+++ b/aegis_gym/scene/scene_director_factory.py
@@ -23,7 +23,7 @@ class SceneDirectorType(StrEnum):
 
 def get_scene_director(
     mode: SceneDirectorType = SceneDirectorType.ROS,
-    visual_obs: bool = False,
+    enable_scene_camera: bool = False,
 ) -> SceneDirectorInterface:
     if is_mock_needed():
         print("\n> Deteceted pytest env, using MOCK env implementations.")
@@ -53,7 +53,7 @@ def get_scene_director(
                 SceneDirectorSimGenesis = None
 
             if SceneDirectorSimGenesis:
-                return SceneDirectorSimGenesis(visual_obs=visual_obs)
+                return SceneDirectorSimGenesis(enable_scene_camera=enable_scene_camera)
             warnings.warn(
                 "\n[IMPORT ERROR] Failed to import SceneDirectorSimGenesis. Double check if the 'aegis_gym' is instatalled with optional dependencies: 'pip3 install ./aegis_gym.whl[sim-genesis]'."
             )

--- a/aegis_gym/sim/genesis/__init__.py
+++ b/aegis_gym/sim/genesis/__init__.py
@@ -18,7 +18,7 @@ ENV_IDS = []
 
 sim_name = SceneDirectorType.SIM_GENESIS.value
 tasks = ["Reacher", "Pusher"]
-obs_types = [EnvObservationType.STATE]
+obs_types = [EnvObservationType.STATE, EnvObservationType.VISION]
 control_types = [
     EnvControlType.JOINTS,
     EnvControlType.JOINTS_SERVO,

--- a/aegis_gym/sim/genesis/__init__.py
+++ b/aegis_gym/sim/genesis/__init__.py
@@ -18,7 +18,7 @@ ENV_IDS = []
 
 sim_name = SceneDirectorType.SIM_GENESIS.value
 tasks = ["Reacher", "Pusher"]
-obs_types = [EnvObservationType.STATE, EnvObservationType.VISION]
+obs_types = [EnvObservationType.STATE, EnvObservationType.MULTIMODAL]
 control_types = [
     EnvControlType.JOINTS,
     EnvControlType.JOINTS_SERVO,

--- a/aegis_gym/sim/genesis/scene_director_genesis.py
+++ b/aegis_gym/sim/genesis/scene_director_genesis.py
@@ -42,9 +42,11 @@ class SceneDirectorSimGenesis(SceneDirectorInterface):
         device: str = "cuda",
         show_render: bool = True,
         cfg: dict = SIM_CFG,
+        visual_obs: bool = False,
     ):
         super().__init__(device, show_render)
         self.cfg = cfg
+        self.visual_obs = visual_obs
         self.motor_dofs: tuple[int] = None
 
         if not gs._initialized:
@@ -95,6 +97,16 @@ class SceneDirectorSimGenesis(SceneDirectorInterface):
             surface=gs.surfaces.Default(color=(0.5, 0.5, 0.5)),
             material=gs.materials.Rigid(friction=0.6, coup_friction=0.6),
         )
+
+        if self.visual_obs:
+            self.camera = self.scene.add_camera(
+                res=(1280, 720),
+                pos=(0.014, 0.33, 1.972),
+                lookat=(0.014, 0.33, 0.0),
+                up=(0, 0, -1),
+                fov=50,
+                GUI=True,
+            )
 
     def get_robot_commander(self) -> RobotCommanderInterface:
         return RobotCommanderSimGenesis(self.robot, self.motor_dofs, self.device)

--- a/aegis_gym/sim/genesis/scene_director_genesis.py
+++ b/aegis_gym/sim/genesis/scene_director_genesis.py
@@ -48,6 +48,7 @@ class SceneDirectorSimGenesis(SceneDirectorInterface):
         self.cfg = cfg
         self.enable_scene_camera = enable_scene_camera
         self.motor_dofs: tuple[int] = None
+        self.camera = None
 
         if not gs._initialized:
             backend = gs.gpu if device in ("cuda", "gpu") else gs.cpu

--- a/aegis_gym/sim/genesis/scene_director_genesis.py
+++ b/aegis_gym/sim/genesis/scene_director_genesis.py
@@ -42,11 +42,11 @@ class SceneDirectorSimGenesis(SceneDirectorInterface):
         device: str = "cuda",
         show_render: bool = True,
         cfg: dict = SIM_CFG,
-        visual_obs: bool = False,
+        enable_scene_camera: bool = False,
     ):
         super().__init__(device, show_render)
         self.cfg = cfg
-        self.visual_obs = visual_obs
+        self.enable_scene_camera = enable_scene_camera
         self.motor_dofs: tuple[int] = None
 
         if not gs._initialized:
@@ -98,7 +98,7 @@ class SceneDirectorSimGenesis(SceneDirectorInterface):
             material=gs.materials.Rigid(friction=0.6, coup_friction=0.6),
         )
 
-        if self.visual_obs:
+        if self.enable_scene_camera:
             self.camera = self.scene.add_camera(
                 res=(1280, 720),
                 pos=(0.014, 0.33, 1.972),

--- a/aegis_gym/sim/genesis/scene_entities_genesis.py
+++ b/aegis_gym/sim/genesis/scene_entities_genesis.py
@@ -28,7 +28,9 @@ class TargetSimGenesis(Target):
         self._pose = pose.clone()
 
     def get_pose(self) -> th.Tensor:
-        return self._pose
+        pos = th.tensor(self._obj.get_pos(), device=self._device)
+        ori = th.tensor(self._obj.get_quat(), device=self._device)
+        return th.cat([pos, ori]).clone()
 
 
 class BoxSimGenesis(Box):
@@ -59,7 +61,9 @@ class BoxSimGenesis(Box):
         self._pose = pose.clone()
 
     def get_pose(self) -> th.Tensor:
-        return self._pose
+        pos = th.tensor(self._obj.get_pos(), device=self._device)
+        ori = th.tensor(self._obj.get_quat(), device=self._device)
+        return th.cat([pos, ori]).clone()
 
 
 EntityTypeSimGenesis = {

--- a/aegis_gym/sim/genesis/scene_entities_genesis.py
+++ b/aegis_gym/sim/genesis/scene_entities_genesis.py
@@ -22,6 +22,7 @@ class TargetSimGenesis(Target):
         pose = [*pos, 0.0, 0.0, 0.0, 1.0]
         self._pose = th.tensor(pose, device=self._device)
 
+    #TODO(issue #29): Verify necessity of tensor cloning
     def set_pose(self, pose: th.Tensor) -> None:
         self._obj.set_pos(pos=pose[:3].view(3), zero_velocity=True)
         self._obj.set_quat(quat=pose[3:].view(4), zero_velocity=True)
@@ -55,6 +56,7 @@ class BoxSimGenesis(Box):
         pose = [*pos, 0.0, 0.0, 0.0, 1.0]
         self._pose = th.tensor(pose, device=self._device)
 
+    #TODO(issue #29): Verify necessity of tensor cloning
     def set_pose(self, pose: th.Tensor) -> None:
         self._obj.set_pos(pos=pose[:3].view(3), zero_velocity=True)
         self._obj.set_quat(quat=pose[3:].view(4), zero_velocity=True)

--- a/aegis_gym/sim/genesis/scene_entities_genesis.py
+++ b/aegis_gym/sim/genesis/scene_entities_genesis.py
@@ -22,7 +22,7 @@ class TargetSimGenesis(Target):
         pose = [*pos, 0.0, 0.0, 0.0, 1.0]
         self._pose = th.tensor(pose, device=self._device)
 
-    #TODO(issue #29): Verify necessity of tensor cloning
+    # TODO(issue #29): Verify necessity of tensor cloning
     def set_pose(self, pose: th.Tensor) -> None:
         self._obj.set_pos(pos=pose[:3].view(3), zero_velocity=True)
         self._obj.set_quat(quat=pose[3:].view(4), zero_velocity=True)
@@ -56,7 +56,7 @@ class BoxSimGenesis(Box):
         pose = [*pos, 0.0, 0.0, 0.0, 1.0]
         self._pose = th.tensor(pose, device=self._device)
 
-    #TODO(issue #29): Verify necessity of tensor cloning
+    # TODO(issue #29): Verify necessity of tensor cloning
     def set_pose(self, pose: th.Tensor) -> None:
         self._obj.set_pos(pos=pose[:3].view(3), zero_velocity=True)
         self._obj.set_quat(quat=pose[3:].view(4), zero_velocity=True)


### PR DESCRIPTION
## Description
This PR adds support for visual observations in Genesis environments.
When multimodal observation type is selected, a static camera is added to the Genesis scene, and the observation returned by the environment includes both a state vector without target position and an RGB image captured by the camera.
Additionally, this PR fixes pose retrieval for Genesis entities to ensure that object positions and orientations are always fetched directly from the simulator state.


## Motivation and context
This change enables conducting visual reinforcement learning experiments in the Genesis simulator, allowing agents to learn from camera-based input instead of pure state vectors. It serves as a foundation for comparing state-based and vision-based policies in future research.


## How has this been tested?
In Genesis.


## Checklist
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.