### PR TITLE
Refine Genesis simulation configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
-    rev: v0.8.0
+    rev: v0.9.0
     hooks:
     -   id: pre-commit-update
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [PR-31](https://github.com/AGH-CEAI/pull/31) - Introduced control frequency parameter to decouple policy updates from physics steps in Genesis.
 - [PR-28](https://github.com/AGH-CEAI/pull/28) - `AegisReacher`: Observation normalization for TCP and Target positions.
 - [PR-26](https://github.com/AGH-CEAI/pull/26) - Added support for multimodal observations in environments.
 - [PR-26](https://github.com/AGH-CEAI/pull/26) - Added a scene camera to Genesis simulation for visual observations.
@@ -21,7 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- [PR-21](https://github.com/AGH-CEAI/aegis_gym/pull/21) - Changed robot PD gains in Genesis.
+- [PR-31](https://github.com/AGH-CEAI/aegis_gym/pull/31) - Changed physics timesteps and substeps.
+- [PR-31](https://github.com/AGH-CEAI/aegis_gym/pull/31) - Changed robot joint PD gains in Genesis.
+- [PR-21](https://github.com/AGH-CEAI/aegis_gym/pull/21) - Changed robot joint PD gains in Genesis.
 - [PR-21](https://github.com/AGH-CEAI/aegis_gym/pull/21) - Differentiated between synchronous and asynchronous control methods.
 - [PR-11,12,13,14,15](https://github.com/AGH-CEAI/aegis_gym/pull/5) - REFACTOR: Abstract interfaces for Genesis sim and ROS control.
 - [PR-4](https://github.com/AGH-CEAI/aegis_gym/pull/4) - Updated & fixed dependencies versions.

--- a/aegis_gym/sim/genesis/scene_director_genesis.py
+++ b/aegis_gym/sim/genesis/scene_director_genesis.py
@@ -29,8 +29,8 @@ SIM_CFG = {
         # 'robotiq_hande_right_finger_joint',
     ],
     # TODO(issue#16): Research tuning of PD gains for UR5e
-    "kp": [1000, 1000, 1000, 500, 500, 500],
-    "kd": [200, 200, 200, 100, 100, 100],
+    "kp": [12000, 12000, 12000, 6000, 6000, 6000],
+    "kd": [2000, 2000, 2000, 1000, 1000, 1000],
 }
 
 

--- a/aegis_gym/sim/genesis/scene_director_genesis.py
+++ b/aegis_gym/sim/genesis/scene_director_genesis.py
@@ -13,7 +13,9 @@ from .scene_entities_genesis import EntityTypeSimGenesis
 
 # TODO(issue#24): Include robot fingers in DOF configuration in Genesis
 SIM_CFG = {
-    "dt": 0.05,
+    "sim_dt": 0.01,
+    "sim_substeps": 2,
+    "ctrl_freq": 20,
     "robot_pos": [0.0, 0.0, 0.0],
     "table_pos": [0.0, 0.6, 0.41],
     "dof_names": [
@@ -53,22 +55,29 @@ class SceneDirectorSimGenesis(SceneDirectorInterface):
         if not gs._initialized:
             backend = gs.gpu if device in ("cuda", "gpu") else gs.cpu
             gs.init(precision="32", backend=backend, logging_level="warning")
-        self.dt = cfg["dt"]
+
+        self.sim_dt = cfg["sim_dt"]
+        self.sim_substeps = cfg["sim_substeps"]
+        self.steps_per_ctrl = int(1.0 / (self.sim_dt * cfg["ctrl_freq"]))
+
+        print("steps per ctrl:", self.steps_per_ctrl)
 
         self._create_scene()
 
     def _create_scene(self) -> None:
         self.scene = gs.Scene(
-            sim_options=gs.options.SimOptions(dt=self.dt, substeps=5),
+            sim_options=gs.options.SimOptions(
+                dt=self.sim_dt, substeps=self.sim_substeps
+            ),
             viewer_options=gs.options.ViewerOptions(
-                max_FPS=int(1.0 / self.dt),
+                max_FPS=int(1.0 / self.sim_dt),
                 camera_pos=(2.0, 0.0, 2.5),
                 camera_lookat=(0.0, 0.0, 0.5),
                 camera_fov=40,
             ),
             vis_options=gs.options.VisOptions(),
             rigid_options=gs.options.RigidOptions(
-                dt=self.dt,
+                dt=self.sim_dt,
                 constraint_solver=gs.constraint_solver.Newton,
                 enable_collision=True,
                 # enable_self_collision=True,
@@ -132,4 +141,7 @@ class SceneDirectorSimGenesis(SceneDirectorInterface):
         self.robot.set_dofs_kv(self.cfg["kd"], self.motor_dofs)
 
     def step(self) -> None:
-        self.scene.step()
+        print("CTRL")
+        for _ in range(self.steps_per_ctrl):
+            self.scene.step()
+            print("sim step")

--- a/aegis_gym/sim/genesis/scene_director_genesis.py
+++ b/aegis_gym/sim/genesis/scene_director_genesis.py
@@ -60,8 +60,6 @@ class SceneDirectorSimGenesis(SceneDirectorInterface):
         self.sim_substeps = cfg["sim_substeps"]
         self.steps_per_ctrl = int(1.0 / (self.sim_dt * cfg["ctrl_freq"]))
 
-        print("steps per ctrl:", self.steps_per_ctrl)
-
         self._create_scene()
 
     def _create_scene(self) -> None:
@@ -141,7 +139,5 @@ class SceneDirectorSimGenesis(SceneDirectorInterface):
         self.robot.set_dofs_kv(self.cfg["kd"], self.motor_dofs)
 
     def step(self) -> None:
-        print("CTRL")
         for _ in range(self.steps_per_ctrl):
             self.scene.step()
-            print("sim step")


### PR DESCRIPTION
## Description
This PR updates the simulation timing and control gains in the Genesis scene director to achieve more realistic, stable and responsive robot dynamics.
The simulation was configured with a physics timestep of 0.01 s (100 Hz) and 2 substeps per physics step, which act as internal solver iterations to improve numerical stability and contact resolution.
The control (policy) frequency was set to 20 Hz, meaning that each control action from the agent is applied over 5 physics steps before a new command is issued.
In addition, proportional–derivative (PD) gains for the UR5e joints were increased, resulting in a stiffer and faster-responding controller that produces smoother motion and reduced oscillations.


## Motivation and context
The previous configuration used a single timestep without explicit control frequency separation, which could lead to inconsistent physics–control synchronization and unrealistic timing.


## How has this been tested?
In Genesis.

## Checklist
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.