### PR TITLE
Change target spawn range in Reacher environment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
-    rev: v0.8.0
+    rev: v0.9.0
     hooks:
     -   id: pre-commit-update
 
@@ -40,7 +40,7 @@ repos:
         args: [-w, --ignore-words=.codespell-ignore-words]
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.3
+    rev: v0.14.5
     hooks:
     -   id: ruff-check
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
         args: [-w, --ignore-words=.codespell-ignore-words]
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.5
+    rev: v0.14.6
     hooks:
     -   id: ruff-check
         args:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [PR-36](https://github.com/AGH-CEAI/aegis_gym/pull/36) - Changed target spawn ranges in Reacher environment.
 - [PR-21](https://github.com/AGH-CEAI/aegis_gym/pull/21) - Changed robot PD gains in Genesis.
 - [PR-21](https://github.com/AGH-CEAI/aegis_gym/pull/21) - Differentiated between synchronous and asynchronous control methods.
 - [PR-11,12,13,14,15](https://github.com/AGH-CEAI/aegis_gym/pull/5) - REFACTOR: Abstract interfaces for Genesis sim and ROS control.

--- a/aegis_gym/envs/aegis_reacher.py
+++ b/aegis_gym/envs/aegis_reacher.py
@@ -22,9 +22,21 @@ from .env_types import EnvControlType, EnvObservationType, EnvRewardType, EnvRen
 ENV_CFG = {
     "max_episode_length": 1000,
     "target_threshold": 0.02,
-    "target_spawn_x": [-0.26, 0.26],
-    "target_spawn_y": [0.36, 1.0],
-    "target_spawn_z": [0.98, 1.78],
+    # target spawn range inside camera FOV
+    "target_spawn_x": [-0.3, 0.3],
+    "target_spawn_y": [0.34, 0.58],
+    "target_spawn_z": [0.86, 1.4],
+
+    # wider target spawn range
+    # "target_spawn_x": [-0.3, 0.3],
+    # "target_spawn_y": [0.34, 0.8],
+    # "target_spawn_z": [0.86, 1.66],
+
+    # target spawn range for end-effector pointing down
+    # "target_spawn_x": [-0.3, 0.3],
+    # "target_spawn_y": [0.34, 0.58],
+    # "target_spawn_z": [0.86, 1.22],
+
     "clip_action": 1,
     "action_scale": 0.1,
     "obs_scales": {"dof_pos": 1.0, "dof_vel": 0.1},

--- a/aegis_gym/envs/aegis_reacher.py
+++ b/aegis_gym/envs/aegis_reacher.py
@@ -26,17 +26,14 @@ ENV_CFG = {
     "target_spawn_x": [-0.3, 0.3],
     "target_spawn_y": [0.34, 0.58],
     "target_spawn_z": [0.86, 1.4],
-
     # wider target spawn range
     # "target_spawn_x": [-0.3, 0.3],
     # "target_spawn_y": [0.34, 0.8],
     # "target_spawn_z": [0.86, 1.66],
-
     # target spawn range for end-effector pointing down
     # "target_spawn_x": [-0.3, 0.3],
     # "target_spawn_y": [0.34, 0.58],
     # "target_spawn_z": [0.86, 1.22],
-
     "clip_action": 1,
     "action_scale": 0.1,
     "obs_scales": {"dof_pos": 1.0, "dof_vel": 0.1},


### PR DESCRIPTION
## Description
This PR updates the target spawn regions used in the Reacher environment.
Three predefined spawn ranges are now provided:
* Camera-visible spawn range – targets are guaranteed to appear inside the camera's field of view, suitable for vision-based training.
* Wide spawn range – targets may spawn outside the camera view, intended for state-based training.
* Fixed end-effector orientation spawn range – target positions compatible with a constant end-effector pointing down.


## Motivation and context
This PR introduces a clearly defined spawn range that is compatible with the camera’s field of view, and additionally provides predefined ranges for other setup types.


## How has this been tested?
On the real hardware and in Genesis.


## Checklist
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.
