### PR TITLE
Add scene and tool cameras setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
         args: [-w, --ignore-words=.codespell-ignore-words]
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.10
+    rev: v0.14.11
     hooks:
     -   id: ruff-check
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
         args: [-w, --ignore-words=.codespell-ignore-words]
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.9
+    rev: v0.14.10
     hooks:
     -   id: ruff-check
         args:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [PR-40](https://github.com/AGH-CEAI/pull/40) - Added scene and tool cameras setup for Grasp environment.
 - [PR-39](https://github.com/AGH-CEAI/pull/39) - Added Grasp environment compatible with RSL-RL.
 - [PR-32](https://github.com/AGH-CEAI/pull/32) - `ROSRoboticCommander`: Added servoing (twist/jog) with MoveIt2 Servo.
 - [PR-31](https://github.com/AGH-CEAI/pull/31) - Introduced control frequency parameter to decouple policy updates from physics steps in Genesis.

--- a/aegis_gym/rsl/README.md
+++ b/aegis_gym/rsl/README.md
@@ -31,3 +31,9 @@ python3 grasp_eval.py --stage=bc
 ```bash
 python3 grasp_eval.py --stage=bc --record
 ```
+
+## Camera Setups
+The environment supports configurable camera layouts, allowing different perception setups to be selected at initialization time.
+Currently, two camera setups are available:
+* **default** – matches the real robot setup (without the front tool camera): one static top-down scene camera plus two eye-in-hand cameras moving with the end-effector
+* **dual_scene** – legacy configuration: two static scene cameras forming a stereo view from the front

--- a/aegis_gym/rsl/behavior_cloning.py
+++ b/aegis_gym/rsl/behavior_cloning.py
@@ -20,8 +20,15 @@ class BehaviorCloning:
         self._teacher = teacher
         self._num_steps_per_env = cfg["num_steps_per_env"]
 
-        # Stereo RGB: 6 channels (3 left + 3 right)
-        rgb_shape = (6, env.image_height, env.image_width)
+        if env.camera_setup == "default":
+            num_cameras = 3
+        elif env.camera_setup == "scene_dual":
+            num_cameras = 2
+        else:
+            raise ValueError(f"Unknown camera_setup: {env.camera_setup}")
+
+        cfg["policy"]["num_cameras"] = num_cameras
+        rgb_shape = (num_cameras * 3, env.image_height, env.image_width)
         action_dim = env.num_actions
 
         # Multi-task policy with action and pose heads
@@ -74,21 +81,17 @@ class BehaviorCloning:
             for batch in generator:
                 # Forward pass for both action and pose prediction
                 pred_action = self._policy(batch["rgb_obs"], batch["robot_pose"])
-                pred_left_pose, pred_right_pose = self._policy.predict_pose(
-                    batch["rgb_obs"]
-                )
+                pred_poses = self._policy.predict_pose(batch["rgb_obs"])
 
                 # Compute action prediction loss
                 action_loss = F.mse_loss(pred_action, batch["actions"])
 
                 # Compute pose estimation loss (position + orientation)
-                pose_left_loss = self._compute_pose_loss(
-                    pred_left_pose, batch["object_poses"]
-                )
-                pose_right_loss = self._compute_pose_loss(
-                    pred_right_pose, batch["object_poses"]
-                )
-                pose_loss = pose_left_loss + pose_right_loss
+                pose_loss = 0.0
+                for pred_pose in pred_poses:
+                    pose_loss += self._compute_pose_loss(
+                        pred_pose, batch["object_poses"]
+                    )
 
                 # Combined loss with weights
                 total_loss = action_loss + pose_loss
@@ -185,8 +188,8 @@ class BehaviorCloning:
         obs, _ = self._env.get_observations()
         with torch.inference_mode():
             for _ in range(self._num_steps_per_env):
-                # Get stereo rgb images
-                rgb_obs = self._env.get_stereo_rgb_images(normalize=True)
+                # rgb_obs = self._env.get_stereo_rgb_images(normalize=True)
+                rgb_obs = self._env.get_observations_vis(normalize=True)
 
                 # Get teacher action
                 teacher_action = self._teacher(obs).detach()
@@ -353,11 +356,10 @@ class Policy(nn.Module):
 
     def __init__(self, config: dict, action_dim: int):
         super().__init__()
+        self.num_cameras = config["num_cameras"]
 
-        # Shared encoder for both left and right cameras
         self.shared_encoder = self._build_cnn(config["vision_encoder"])
 
-        # Feature fusion layer to combine stereo features
         vision_encoder_conv_out_channels = config["vision_encoder"]["conv_layers"][-1][
             "out_channels"
         ]
@@ -365,8 +367,8 @@ class Policy(nn.Module):
 
         self.feature_fusion = nn.Sequential(
             nn.Linear(
-                vision_encoder_output_dim * 2, vision_encoder_output_dim
-            ),  # 2 cameras
+                vision_encoder_output_dim * self.num_cameras, vision_encoder_output_dim
+            ),
             nn.ReLU(),
             nn.Dropout(0.1),
         )
@@ -429,25 +431,25 @@ class Policy(nn.Module):
         layers.append(nn.Linear(mlp_input_dim, config["output_dim"]))
         return nn.Sequential(*layers)
 
-    def get_features(self, rgb_obs: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        # Split stereo rgb images
-        left_rgb = rgb_obs[:, 0:3]  # First 3 channels (RGB)
-        right_rgb = rgb_obs[:, 3:6]  # Last 3 channels (RGB)
+    def get_features(self, rgb_obs: torch.Tensor) -> list[torch.Tensor]:
+        # Split rgb images
+        camera_features = []
+        for i in range(self.num_cameras):
+            cam_rgb = rgb_obs[:, i * 3 : (i + 1) * 3]
+            cam_features = self.shared_encoder(cam_rgb).flatten(start_dim=1)
+            camera_features.append(cam_features)
 
-        # Use shared encoder for both images
-        left_features = self.shared_encoder(left_rgb).flatten(start_dim=1)
-        right_features = self.shared_encoder(right_rgb).flatten(start_dim=1)
-        return left_features, right_features
+        return camera_features
 
     def forward(
         self, rgb_obs: torch.Tensor, state_obs: torch.Tensor | None = None
     ) -> dict:
         """Forward pass with shared stereo encoder for rgb images."""
         # Get features
-        left_features, right_features = self.get_features(rgb_obs)
+        features_list = self.get_features(rgb_obs)
 
         # Concatenate features (much more efficient than concatenating raw images)
-        combined_features = torch.cat([left_features, right_features], dim=-1)
+        combined_features = torch.cat(features_list, dim=-1)
         # Feature fusion
         fused_features = self.feature_fusion(combined_features)
 
@@ -460,9 +462,8 @@ class Policy(nn.Module):
         # Predict actions
         return self.mlp(final_features)
 
-    def predict_pose(self, rgb_obs: torch.Tensor) -> torch.Tensor:
+    def predict_pose(self, rgb_obs: torch.Tensor) -> list[torch.Tensor]:
         """Predict pose from rgb images and state observations."""
-        left_features, right_features = self.get_features(rgb_obs)
-        left_pose = self.pose_mlp(left_features)
-        right_pose = self.pose_mlp(right_features)
-        return left_pose, right_pose
+        features_list = self.get_features(rgb_obs)
+        poses = [self.pose_mlp(features) for features in features_list]
+        return poses

--- a/aegis_gym/rsl/behavior_cloning.py
+++ b/aegis_gym/rsl/behavior_cloning.py
@@ -188,7 +188,6 @@ class BehaviorCloning:
         obs, _ = self._env.get_observations()
         with torch.inference_mode():
             for _ in range(self._num_steps_per_env):
-                # rgb_obs = self._env.get_stereo_rgb_images(normalize=True)
                 rgb_obs = self._env.get_observations_vis(normalize=True)
 
                 # Get teacher action
@@ -462,8 +461,8 @@ class Policy(nn.Module):
         # Predict actions
         return self.mlp(final_features)
 
-    def predict_pose(self, rgb_obs: torch.Tensor) -> list[torch.Tensor]:
+    def predict_pose(self, rgb_obs: torch.Tensor) -> tuple[torch.Tensor]:
         """Predict pose from rgb images and state observations."""
         features_list = self.get_features(rgb_obs)
-        poses = [self.pose_mlp(features) for features in features_list]
+        poses = tuple(self.pose_mlp(features) for features in features_list)
         return poses

--- a/aegis_gym/rsl/grasp_env.py
+++ b/aegis_gym/rsl/grasp_env.py
@@ -120,9 +120,9 @@ class GraspEnv:
         # == add cameras ==
         match self.camera_setup:
             case "default":
-                self._add_camera(name="scene_cam", fov=40, res=(800, 400))
-                self._add_camera(name="tool_left_cam", fov=30, res=(800, 400))
-                self._add_camera(name="tool_right_cam", fov=30, res=(800, 400))
+                self._add_camera(name="scene_cam", fov=40)
+                self._add_camera(name="tool_left_cam", fov=30)
+                self._add_camera(name="tool_right_cam", fov=30)
             case "scene_dual":
                 self._add_camera(name="scene_left_cam", pos=(1.25, 0.3, 0.3), fov=60)
                 self._add_camera(name="scene_right_cam", pos=(1.25, -0.3, 0.3), fov=60)

--- a/aegis_gym/rsl/grasp_env.py
+++ b/aegis_gym/rsl/grasp_env.py
@@ -1,6 +1,7 @@
 import math
 import torch
 
+import numpy as np
 import genesis as gs
 from genesis.utils.geom import (
     transform_by_quat,
@@ -26,6 +27,7 @@ class GraspEnv:
         self.image_height = env_cfg["image_resolution"][1]
         self.rgb_image_shape = (3, self.image_height, self.image_width)
         self.show_cell = env_cfg["visualize_cell"]
+        self.camera_setup = env_cfg["camera_setup"]
         self.device = gs.device
 
         self.ctrl_dt = env_cfg["ctrl_dt"]
@@ -39,6 +41,8 @@ class GraspEnv:
         self.scene.build(n_envs=env_cfg["num_envs"])
 
         self.robot.set_pd_gains()
+        self._attach_cameras()
+
         self._init_reward_functions()
         self._init_buffers()
         self.reset()
@@ -112,8 +116,19 @@ class GraspEnv:
                 ),
             ),
         )
+
+        # == add cameras ==
+        match self.camera_setup:
+            case "default":
+                self._add_camera(name="scene_cam", fov=40, res=(800, 400))
+                self._add_camera(name="tool_left_cam", fov=30, res=(800, 400))
+                self._add_camera(name="tool_right_cam", fov=30, res=(800, 400))
+            case "scene_dual":
+                self._add_camera(name="scene_left_cam", pos=(1.25, 0.3, 0.3), fov=60)
+                self._add_camera(name="scene_right_cam", pos=(1.25, -0.3, 0.3), fov=60)
+
         if self.env_cfg["visualize_camera"]:
-            self.vis_cam = self.scene.add_camera(
+            self.record_cam = self.scene.add_camera(
                 res=(1280, 720),
                 pos=(1.5, 0.0, 0.2),
                 lookat=(0.0, 0.0, 0.2),
@@ -122,21 +137,61 @@ class GraspEnv:
                 debug=True,
             )
 
-        # == add stereo camera ==
-        self.left_cam = self.scene.add_camera(
-            res=(self.image_width, self.image_height),
-            pos=(1.25, 0.3, 0.3),
-            lookat=(0.0, 0.0, 0.0),
-            fov=60,
-            GUI=self.env_cfg["visualize_camera"],
+    def _add_camera(
+        self,
+        name: str,
+        pos: tuple = (0.0, 0.0, 0.0),
+        fov: float = 40,
+        lookat: tuple = (0.0, 0.0, 0.0),
+        res: tuple = None,
+    ):
+        if res is None:
+            res = (self.image_width, self.image_height)
+        setattr(
+            self,
+            name,
+            self.scene.add_camera(
+                res=res,
+                pos=pos,
+                lookat=lookat,
+                fov=fov,
+                GUI=self.env_cfg["visualize_camera"],
+            ),
         )
-        self.right_cam = self.scene.add_camera(
-            res=(self.image_width, self.image_height),
-            pos=(1.25, -0.3, 0.3),
-            lookat=(0.0, 0.0, 0.0),
-            fov=60,
-            GUI=self.env_cfg["visualize_camera"],
+
+    def _attach_cameras(self):
+        if self.camera_setup != "default":
+            return
+
+        scene_offset_T = np.array(
+            [
+                [0.0, 0.0, -1.0, 0.0],
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, -1.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ],
+            dtype=np.float32,
         )
+        tool_offset_T = np.array(
+            [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, -0.03],
+                [0.0, 0.0, 0.0, 1.0],
+            ],
+            dtype=np.float32,
+        )
+
+        cams_to_attach = [
+            ("scene_cam", "cam_scene_rgb_camera_frame", scene_offset_T),
+            ("tool_left_cam", "cam_tool_left", tool_offset_T),
+            ("tool_right_cam", "cam_tool_right", tool_offset_T),
+        ]
+
+        for cam_name, link_name, offset in cams_to_attach:
+            cam = getattr(self, cam_name)
+            cam.attach(self.robot._robot_entity.get_link(link_name), offset)
+            cam.move_to_attach()
 
     def _init_reward_functions(self) -> None:
         self.reward_functions, self.episode_sums = dict(), dict()
@@ -284,10 +339,10 @@ class GraspEnv:
         return obs_tensor, self.extras
 
     def get_stereo_rgb_images(self, normalize: bool = True) -> torch.Tensor:
-        rgb_left, _, _, _ = self.left_cam.render(
+        rgb_left, _, _, _ = self.scene_left_cam.render(
             rgb=True, depth=False, segmentation=False, normal=False
         )
-        rgb_right, _, _, _ = self.right_cam.render(
+        rgb_right, _, _, _ = self.scene_right_cam.render(
             rgb=True, depth=False, segmentation=False, normal=False
         )
 
@@ -303,6 +358,28 @@ class GraspEnv:
         # concatenate left and right rgb images along channel dimension
         stereo_rgb = torch.cat([rgb_left, rgb_right], dim=1)
         return stereo_rgb
+
+    def get_observations_vis(self, normalize: bool = True) -> torch.Tensor:
+        match self.camera_setup:
+            case "default":
+                cams = [self.scene_cam, self.tool_left_cam, self.tool_right_cam]
+            case "scene_dual":
+                cams = [self.scene_left_cam, self.scene_right_cam]
+            case _:
+                raise ValueError(f"Unknown camera setup {self.camera_setup}")
+
+        rgb_list = []
+        for cam in cams:
+            rgb, _, _, _ = cam.render(
+                rgb=True, depth=False, segmentation=False, normal=False
+            )
+            rgb = rgb.permute(0, 3, 1, 2)[:, :3]
+            if normalize:
+                rgb = torch.clamp(rgb, 0.0, 255.0) / 255.0
+            rgb_list.append(rgb)
+
+        rgb_multi = torch.cat(rgb_list, dim=1)
+        return rgb_multi
 
     def _reward_keypoints(self) -> torch.Tensor:
         ee_pos = self.robot.ee_pose[:, :3]

--- a/aegis_gym/rsl/grasp_env.py
+++ b/aegis_gym/rsl/grasp_env.py
@@ -137,11 +137,12 @@ class GraspEnv:
                 debug=True,
             )
 
+    # TODO(issue#41): Refactor camera handling to use a unified camera registry instead of dynamic attributes
     def _add_camera(
         self,
         name: str,
         pos: tuple = (0.0, 0.0, 0.0),
-        fov: float = 40,
+        fov: float = 40,  # deg
         lookat: tuple = (0.0, 0.0, 0.0),
         res: tuple = None,
     ):

--- a/aegis_gym/rsl/grasp_eval.py
+++ b/aegis_gym/rsl/grasp_eval.py
@@ -86,9 +86,6 @@ def main():
     with torch.no_grad():
         if args.record:
             print("Recording video...")
-            # env.vis_cam.start_recording()
-            # env.left_cam.start_recording()
-            # env.right_cam.start_recording()
             if env.cfg["camera_setup"] == "default":
                 env.record_cam.start_recording()
                 env.scene_cam.start_recording()
@@ -119,15 +116,6 @@ def main():
         env.grasp_and_lift_demo()
         if args.record:
             print("Stopping video recording...")
-            # env.vis_cam.stop_recording(
-            #     save_to_filename="video.mp4", fps=env_cfg["max_visualize_FPS"]
-            # )
-            # env.left_cam.stop_recording(
-            #     save_to_filename="left_cam.mp4", fps=env_cfg["max_visualize_FPS"]
-            # )
-            # env.right_cam.stop_recording(
-            #     save_to_filename="right_cam.mp4", fps=env_cfg["max_visualize_FPS"]
-            # )
             if env.cfg["camera_setup"] == "default":
                 env.record_cam.stop_recording(
                     save_to_filename=args.video_path,

--- a/aegis_gym/rsl/grasp_eval.py
+++ b/aegis_gym/rsl/grasp_eval.py
@@ -88,17 +88,17 @@ def main():
             # env.vis_cam.start_recording()
             # env.left_cam.start_recording()
             # env.right_cam.start_recording()
-            if env.cfg["camera_setup"] == "default":
+            if env_cfg["camera_setup"] == "default":
                 env.record_cam.start_recording()
                 env.scene_cam.start_recording()
                 env.tool_left_cam.start_recording()
                 env.tool_right_cam.start_recording()
-            elif env.cfg["camera_setup"] == "scene_dual":
+            elif env_cfg["camera_setup"] == "scene_dual":
                 env.record_cam.start_recording()
                 env.scene_left_cam.start_recording()
                 env.scene_right_cam.start_recording()
             else:
-                raise RuntimeError(f"Unknown camera_setup: {env.cfg['camera_setup']}")
+                raise RuntimeError(f"Unknown camera_setup: {env_cfg['camera_setup']}")
         for step in range(max_sim_step):
             if args.stage == "rl":
                 actions = policy(obs)
@@ -111,7 +111,7 @@ def main():
 
                 # Collect frame for video recording
                 if args.record:
-                    env.vis_cam.render()  # render the visualization camera
+                    env.record_cam.render()  # render the visualization camera
 
             obs, rews, dones, infos = env.step(actions)
         env.grasp_and_lift_demo()
@@ -126,7 +126,7 @@ def main():
             # env.right_cam.stop_recording(
             #     save_to_filename="right_cam.mp4", fps=env_cfg["max_visualize_FPS"]
             # )
-            if env.cfg["camera_setup"] == "default":
+            if env_cfg["camera_setup"] == "default":
                 env.record_cam.stop_recording(
                     save_to_filename=args.video_path,
                     fps=env_cfg["max_visualize_FPS"],
@@ -139,7 +139,7 @@ def main():
                     save_to_filename="tool_right_cam.mp4",
                     fps=env_cfg["max_visualize_FPS"],
                 )
-            elif env.cfg["camera_setup"] == "scene_dual":
+            elif env_cfg["camera_setup"] == "scene_dual":
                 env.record_cam.stop_recording(
                     save_to_filename=args.video_path,
                     fps=env_cfg["max_visualize_FPS"],

--- a/aegis_gym/rsl/grasp_eval.py
+++ b/aegis_gym/rsl/grasp_eval.py
@@ -85,9 +85,20 @@ def main():
     with torch.no_grad():
         if args.record:
             print("Recording video...")
-            env.vis_cam.start_recording()
-            env.left_cam.start_recording()
-            env.right_cam.start_recording()
+            # env.vis_cam.start_recording()
+            # env.left_cam.start_recording()
+            # env.right_cam.start_recording()
+            if env.cfg["camera_setup"] == "default":
+                env.record_cam.start_recording()
+                env.scene_cam.start_recording()
+                env.tool_left_cam.start_recording()
+                env.tool_right_cam.start_recording()
+            elif env.cfg["camera_setup"] == "scene_dual":
+                env.record_cam.start_recording()
+                env.scene_left_cam.start_recording()
+                env.scene_right_cam.start_recording()
+            else:
+                raise RuntimeError(f"Unknown camera_setup: {env.cfg['camera_setup']}")
         for step in range(max_sim_step):
             if args.stage == "rl":
                 actions = policy(obs)
@@ -106,15 +117,41 @@ def main():
         env.grasp_and_lift_demo()
         if args.record:
             print("Stopping video recording...")
-            env.vis_cam.stop_recording(
-                save_to_filename="video.mp4", fps=env_cfg["max_visualize_FPS"]
-            )
-            env.left_cam.stop_recording(
-                save_to_filename="left_cam.mp4", fps=env_cfg["max_visualize_FPS"]
-            )
-            env.right_cam.stop_recording(
-                save_to_filename="right_cam.mp4", fps=env_cfg["max_visualize_FPS"]
-            )
+            # env.vis_cam.stop_recording(
+            #     save_to_filename="video.mp4", fps=env_cfg["max_visualize_FPS"]
+            # )
+            # env.left_cam.stop_recording(
+            #     save_to_filename="left_cam.mp4", fps=env_cfg["max_visualize_FPS"]
+            # )
+            # env.right_cam.stop_recording(
+            #     save_to_filename="right_cam.mp4", fps=env_cfg["max_visualize_FPS"]
+            # )
+            if env.cfg["camera_setup"] == "default":
+                env.record_cam.stop_recording(
+                    save_to_filename=args.video_path,
+                    fps=env_cfg["max_visualize_FPS"],
+                )
+                env.tool_left_cam.stop_recording(
+                    save_to_filename="tool_left_cam.mp4",
+                    fps=env_cfg["max_visualize_FPS"],
+                )
+                env.tool_right_cam.stop_recording(
+                    save_to_filename="tool_right_cam.mp4",
+                    fps=env_cfg["max_visualize_FPS"],
+                )
+            elif env.cfg["camera_setup"] == "scene_dual":
+                env.record_cam.stop_recording(
+                    save_to_filename=args.video_path,
+                    fps=env_cfg["max_visualize_FPS"],
+                )
+                env.scene_left_cam.stop_recording(
+                    save_to_filename="scene_left_cam.mp4",
+                    fps=env_cfg["max_visualize_FPS"],
+                )
+                env.scene_right_cam.stop_recording(
+                    save_to_filename="scene_right_cam.mp4",
+                    fps=env_cfg["max_visualize_FPS"],
+                )
 
 
 if __name__ == "__main__":

--- a/aegis_gym/rsl/grasp_eval.py
+++ b/aegis_gym/rsl/grasp_eval.py
@@ -82,28 +82,30 @@ def main():
 
     max_sim_step = int(env_cfg["episode_length_s"] * env_cfg["max_visualize_FPS"])
 
+    # TODO(issue#41): Refactor camera handling to use a unified camera registry instead of dynamic attributes
     with torch.no_grad():
         if args.record:
             print("Recording video...")
             # env.vis_cam.start_recording()
             # env.left_cam.start_recording()
             # env.right_cam.start_recording()
-            if env_cfg["camera_setup"] == "default":
+            if env.cfg["camera_setup"] == "default":
                 env.record_cam.start_recording()
                 env.scene_cam.start_recording()
                 env.tool_left_cam.start_recording()
                 env.tool_right_cam.start_recording()
-            elif env_cfg["camera_setup"] == "scene_dual":
+            elif env.cfg["camera_setup"] == "scene_dual":
                 env.record_cam.start_recording()
                 env.scene_left_cam.start_recording()
                 env.scene_right_cam.start_recording()
             else:
-                raise RuntimeError(f"Unknown camera_setup: {env_cfg['camera_setup']}")
+                raise RuntimeError(f"Unknown camera_setup: {env.cfg['camera_setup']}")
         for step in range(max_sim_step):
             if args.stage == "rl":
                 actions = policy(obs)
             else:
                 # Get stereo grayscale images and ensure float32
+                # rgb_obs = env.get_stereo_rgb_images(normalize=True).float()
                 rgb_obs = env.get_stereo_rgb_images(normalize=True).float()
                 ee_pose = env.robot.ee_pose.float()
 
@@ -111,7 +113,7 @@ def main():
 
                 # Collect frame for video recording
                 if args.record:
-                    env.record_cam.render()  # render the visualization camera
+                    env.vis_cam.render()  # render the visualization camera
 
             obs, rews, dones, infos = env.step(actions)
         env.grasp_and_lift_demo()
@@ -126,9 +128,13 @@ def main():
             # env.right_cam.stop_recording(
             #     save_to_filename="right_cam.mp4", fps=env_cfg["max_visualize_FPS"]
             # )
-            if env_cfg["camera_setup"] == "default":
+            if env.cfg["camera_setup"] == "default":
                 env.record_cam.stop_recording(
                     save_to_filename=args.video_path,
+                    fps=env_cfg["max_visualize_FPS"],
+                )
+                env.tool_right_cam.stop_recording(
+                    save_to_filename="scene_cam.mp4",
                     fps=env_cfg["max_visualize_FPS"],
                 )
                 env.tool_left_cam.stop_recording(
@@ -139,7 +145,7 @@ def main():
                     save_to_filename="tool_right_cam.mp4",
                     fps=env_cfg["max_visualize_FPS"],
                 )
-            elif env_cfg["camera_setup"] == "scene_dual":
+            elif env.cfg["camera_setup"] == "scene_dual":
                 env.record_cam.stop_recording(
                     save_to_filename=args.video_path,
                     fps=env_cfg["max_visualize_FPS"],

--- a/aegis_gym/rsl/grasp_train.py
+++ b/aegis_gym/rsl/grasp_train.py
@@ -125,7 +125,7 @@ def get_task_cfgs():
         "use_rasterizer": False,
         "visualize_camera": False,
         "visualize_cell": True,
-        "camera_setup": "default",  # default, scene_dual
+        "camera_setup": "default",  # options: default, scene_dual
     }
     reward_scales = {
         "keypoints": 1.0,

--- a/aegis_gym/rsl/grasp_train.py
+++ b/aegis_gym/rsl/grasp_train.py
@@ -125,6 +125,7 @@ def get_task_cfgs():
         "use_rasterizer": False,
         "visualize_camera": False,
         "visualize_cell": True,
+        "camera_setup": "default",  # default, scene_dual
     }
     reward_scales = {
         "keypoints": 1.0,

--- a/aegis_gym/rsl/manipulator.py
+++ b/aegis_gym/rsl/manipulator.py
@@ -32,7 +32,13 @@ class Manipulator:
             fixed=True,
             pos=(0.0, 0.0, 0.0),
             quat=(1.0, 0.0, 0.0, 0.0),
-            links_to_keep=["ur_base", "robotiq_hande_end"],
+            links_to_keep=[
+                "ur_base",
+                "robotiq_hande_end",
+                "cam_tool_right",
+                "cam_tool_left",
+                "cam_scene_rgb_camera_frame",
+            ],
         )
         self._robot_entity: gs.Entity = scene.add_entity(material=material, morph=morph)
 


### PR DESCRIPTION
## Description
This change adds a configurable camera setup mechanism to the environment. A new configuration variable allows selecting between multiple camera layouts at initialization time. The previously used setup, consisting of two static cameras arranged at an angle to form a stereo view of the scene, is preserved. In addition, a new camera setup is introduced that mirrors the perception configuration used on the physical robot. In the new setup, a single static scene camera observes the workspace from above, while two eye-in-hand cameras are mounted near the robot tool and move together with the end-effector. Additional changes are required in the behavior cloning pipeline to properly handle the new camera setups. The design also leaves room for future extensions, such as supporting configurations that use all available cameras, for example three eye-in-hand tool cameras.


## Motivation and context
Previously, the environment supported only a single, fixed camera configuration based on static stereo views. While suitable for early experimentation, this setup does not correspond to the perception system used on the real robot and limits the realism of vision-based experiments. To evaluate policies under conditions closer to the physical system and to support future sim-to-real transfer, it is necessary to replicate the real camera layout in simulation.


## How has this been tested?
In Genesis.


## Checklist
- [x] All TODOs in the code have been resolved or linked to a proper issue.
- [x] Code has been (auto)formatted.
- [x] Documentation (e.g., README, CHANGELOG, Wiki) has been updated.
- [x] All automated checks have passed.